### PR TITLE
Update from deprecated archiveName to archiveFileName

### DIFF
--- a/nirc_ehr/build.gradle
+++ b/nirc_ehr/build.gradle
@@ -13,7 +13,7 @@ dependencies
 tasks.module.dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module)
 
 task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset metadata") {
-    archiveName 'nirc_study_metadata.zip'
+    archiveFileName = 'nirc_study_metadata.zip'
     destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
     from("resources/referenceStudy/") {
         include "study.xml"
@@ -24,7 +24,7 @@ task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble st
 project.tasks.module.dependsOn(project.tasks.metadataStudyArchive)
 
 task('datasetStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset data") {
-    archiveName 'nirc_study.zip'
+    archiveFileName = 'nirc_study.zip'
     destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
     from("resources/referenceStudy/") {
         include "study.xml"


### PR DESCRIPTION
#### Rationale
We get the following warning when configuring the `nirc_ehr` module:
```
> Configure project :server:modules:nircEHRModules:nirc_ehr
The AbstractArchiveTask.archiveName property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveFileName property instead. See https://docs.gradle.org/7.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName for more details.
        at build_361h2ujklw169nh40d9xo2dci$_run_closure3.doCall(/Users/susanhert/Development/labkey/root/server/modules/nircEHRModules/nirc_ehr/build.gradle:16)
```

#### Changes
* Update to new property name
