### PR TITLE
Support queuing study reloads and ETLs as part of an EHR module upgrade

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -19,6 +19,7 @@ package org.labkey.nirc_ehr;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.ehr.EHRService;
+import org.labkey.api.ehr.SharedEHRUpgradeCode;
 import org.labkey.api.ldk.ExtendedSimpleModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.view.WebPartFactory;
@@ -66,5 +67,11 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     {
         EHRService ehrService = EHRService.get();
         ehrService.registerModule(this);
+    }
+
+    @Override
+    public @NotNull SharedEHRUpgradeCode getUpgradeCode()
+    {
+        return new SharedEHRUpgradeCode(this);
     }
 }


### PR DESCRIPTION
#### Rationale
We want to enable more dev-ops style upgrade operations, including automatically kicking off study reloads and ETLs as part of an EHR module upgrade sequence

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/213
* https://github.com/LabKey/platform/pull/2502
* https://github.com/LabKey/dataintegration/pull/119

#### Changes
* Opt in to EHR upgrade features

Example upgrade script:

SELECT core.executeJavaUpgradeCode('reloadStudy');
SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/demographics');
SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/deaths;truncate');
