### PR TITLE
Pregnancy Outcome and Alopecia ETLs and Reports

### DIFF
--- a/nirc_ehr/resources/data/reports.tsv
+++ b/nirc_ehr/resources/data/reports.tsv
@@ -10,6 +10,7 @@ death	Pathology	query	Death Records	true		study	deaths			date	false	false		qcsta
 currentBlood	Clinical	js	Current Blood	true		study	currentBlood			date	false	false		qcstate/publicdata	This report contains a summary of the current available blood for each animal
 bloodDraws	Clinical	query	Blood Draws	TRUE		study	blood			date	FALSE	FALSE		qcstate/publicdata	This report displays blood draw data for the selected animal
 obs	Clinical	query	Observations	TRUE		study	obs			date	FALSE	FALSE		qcstate/publicdata	This report displays observations for the selected animal
+alopecia	Clinical	query	Alopecia Scores	TRUE		study	alopecia			date	FALSE	FALSE		qcstate/publicdata	This report contains the alopecia scores for the animal
 pairings	Colony Management	query	Pairings	TRUE		study	pairings			date	FALSE	FALSE		qcstate/publicdata	This report displays pairings for the selected animal
 breeder	Colony Management	query	Breeder	TRUE		study	breeder			date	FALSE	FALSE		qcstate/publicdata	This report displays breeding data for the selected animal
 clinremarks	Clinical	query	Clinical Remarks	true		study	Clinical Remarks			date	false	false		qcstate/publicdata	This report contains the clinical remarks entered about each animal

--- a/nirc_ehr/resources/data/reports.tsv
+++ b/nirc_ehr/resources/data/reports.tsv
@@ -21,3 +21,4 @@ exemptions	Colony Management	query	Exemptions	TRUE		study	exemptions			date	FALS
 drugAdministration	Clinical	query	Drug Administration	TRUE		study	drug			date	FALSE	FALSE		qcstate/publicdata	This report displays drug administration data for the selected animal
 necropsy	Pathology	query	Necropsy	TRUE		study	necropsy			date	FALSE	FALSE		qcstate/publicdata	This report displays necropsy data for the selected animal
 cases	Clinical	query	Cases	TRUE		study	cases			date	FALSE	FALSE		qcstate/publicdata	This report displays clinical treatment cases for the selected animal
+pregnancy	Reproductive Management	query	Pregnancy Outcomes	TRUE		study	pregnancy			date	FALSE	FALSE		qcstate/publicdata	This report displays pregnancy outcomes

--- a/nirc_ehr/resources/etls/alopecia.xml
+++ b/nirc_ehr/resources/etls/alopecia.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Alopecia</name>
+    <description>Alopecia Score/Diagnosis</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to alopecia target</description>
+            <source schemaName="dbo" queryName="q_alopecia"/>
+            <destination schemaName="study" queryName="alopecia"
+                         bulkLoad="true" batchSize="5000" targetOption="merge">
+                <columnTransforms>
+                    <column source="administrationDate" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.di.columnTransforms.UserCreateTransform"/>
+                </columnTransforms>
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" >
+        <deletedRowsSource schemaName="dbo" queryName="q_alopecia_delete" timestampColumnName="modified"
+                           deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+    </incrementalFilter>
+
+    <constants>
+        <column type="varchar" name="transformEmailDomain" value="louisiana.edu"/>
+        <column type="varchar" name="userGroupName" value="NIRC ETL USERS"/>
+    </constants>
+    <schedule>
+        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
+    </schedule>
+</etl>

--- a/nirc_ehr/resources/etls/pregnancy.xml
+++ b/nirc_ehr/resources/etls/pregnancy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Pregnancy Outcomes</name>
+    <description>Pregnancy Outcomes</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to pregnancy target</description>
+            <source schemaName="dbo" queryName="q_pregnancy"/>
+            <destination schemaName="study" queryName="pregnancy"
+                         bulkLoad="true" batchSize="5000" targetOption="merge">
+                <columnTransforms>
+                    <column source="administrationDate" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.di.columnTransforms.UserCreateTransform"/>
+                </columnTransforms>
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" >
+        <deletedRowsSource schemaName="dbo" queryName="q_pregnancy_delete" timestampColumnName="modified"
+                           deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+    </incrementalFilter>
+
+    <constants>
+        <column type="varchar" name="transformEmailDomain" value="louisiana.edu"/>
+        <column type="varchar" name="userGroupName" value="NIRC ETL USERS"/>
+    </constants>
+    <schedule>
+        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
+    </schedule>
+</etl>

--- a/nirc_ehr/resources/queries/dbo/q_alopecia.sql
+++ b/nirc_ehr/resources/queries/dbo/q_alopecia.sql
@@ -1,0 +1,33 @@
+SELECT anmEvt.ANIMAL_EVENT_ID                                                    AS objectid,
+       anmEvt.ANIMAL_ID                                                          AS Id,
+       CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP)                                  AS administrationDate,
+       (CASE
+            WHEN anmEvt.STAFF_ID.EMAIL_ADDRESS IS NULL THEN 'unknown'
+            ELSE substr(anmEvt.STAFF_ID.EMAIL_ADDRESS, 1,
+                        instr(anmEvt.STAFF_ID.EMAIL_ADDRESS, '@') - 1) END)      AS performedby,
+       anmEvt.RESULT                                                             AS score,
+       anmEvt.DIAGNOSIS                                                          AS diagnosis,
+       anmCmt.TEXT                                                               AS remark,
+       CAST(COALESCE(max(adt.CHANGE_DATETIME), anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
+FROM ANIMAL_EVENT anmEvt
+         LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
+         LEFT JOIN EVENT_EVENT_GROUP evtEvtGrp ON evtEvtGrp.EVENT_ID = anmEvt.EVENT_ID
+         LEFT JOIN AUDIT_TRAIL adt
+                   ON anmEvt.ANIMAL_EVENT_ID = substring(adt.PRIMARY_KEY_VALUES, length('ANIMAL_EVENT_ID = '))
+                       AND adt.PRIMARY_KEY_VALUES LIKE '%ANIMAL_EVENT_ID%'
+
+WHERE evtEvtGrp.EVENT_ID IN (2293)
+--     2293	Alopecia
+  AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
+
+-- Joining with event_event_group & audit_trail generates duplicate rows, hence the 'group by'
+GROUP BY anmEvt.ANIMAL_EVENT_ID,
+         anmEvt.ANIMAL_ID,
+         anmEvt.EVENT_DATETIME,
+         anmEvt.STAFF_ID.EMAIL_ADDRESS,
+         anmEvt.EVENT_ID.NAME,
+         anmEvt.RESULT,
+         anmEvt.DIAGNOSIS,
+         anmCmt.TEXT,
+         anmEvt.CREATED_DATETIME,
+         adt.CHANGE_DATETIME

--- a/nirc_ehr/resources/queries/dbo/q_alopecia_delete.sql
+++ b/nirc_ehr/resources/queries/dbo/q_alopecia_delete.sql
@@ -1,0 +1,7 @@
+SELECT substring(adt.PRIMARY_KEY_VALUES, length('ANIMAL_EVENT_ID = ')) AS objectid,
+       CAST(adt.CHANGE_DATETIME AS TIMESTAMP)                            AS modified,
+       adt.REFERENCE
+FROM AUDIT_TRAIL adt
+WHERE adt.PRIMARY_KEY_VALUES LIKE '%ANIMAL_EVENT_ID%' AND
+    (adt.REFERENCE LIKE '%Alopecia Event%') AND
+        adt.COLUMN_NAME = 'DELETE'

--- a/nirc_ehr/resources/queries/dbo/q_clinremarks.sql
+++ b/nirc_ehr/resources/queries/dbo/q_clinremarks.sql
@@ -18,3 +18,14 @@ FROM ANIMAL_EVENT anmEvt
 
 WHERE evtEvtGrp.EVENT_GROUP_ID = 53
 --     53 Comments
+
+-- Joining with event_event_group & audit_trail generates duplicate rows, hence the 'group by'
+GROUP BY anmEvt.ANIMAL_EVENT_ID,
+         anmEvt.ANIMAL_ID,
+         anmEvt.EVENT_DATETIME,
+         anmEvt.STAFF_ID.EMAIL_ADDRESS,
+         anmEvt.EVENT_ID.EVENT_ID,
+         anmEvt.DIAGNOSIS,
+         anmCmt.TEXT,
+         anmEvt.CREATED_DATETIME,
+         adt.CHANGE_DATETIME

--- a/nirc_ehr/resources/queries/dbo/q_pregnancy.sql
+++ b/nirc_ehr/resources/queries/dbo/q_pregnancy.sql
@@ -7,9 +7,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
                         instr(anmEvt.STAFF_ID.EMAIL_ADDRESS, '@') - 1) END)      AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
        anmEvt.TEXT_RESULT                                                        AS result,
+       anmEvt.DIAGNOSIS                                                          AS diagnosis,
        anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
        anmCmt.TEXT                                                               AS remark,
-       CAST(COALESCE(adt.CHANGE_DATETIME, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
+       CAST(COALESCE(max(adt.CHANGE_DATETIME), anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
          LEFT JOIN EVENT_EVENT_GROUP evtEvtGrp ON evtEvtGrp.EVENT_ID = anmEvt.EVENT_ID
@@ -17,8 +18,10 @@ FROM ANIMAL_EVENT anmEvt
                    ON anmEvt.ANIMAL_EVENT_ID = substring(adt.PRIMARY_KEY_VALUES, length('ANIMAL_EVENT_ID = '))
                        AND adt.PRIMARY_KEY_VALUES LIKE '%ANIMAL_EVENT_ID%'
 
-WHERE evtEvtGrp.EVENT_GROUP_ID = 56
---     56 Breeder
+WHERE evtEvtGrp.EVENT_ID IN (2170, 2171)
+--     2170	Abort
+--     2171	Stillborn
+    AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
 
 -- Joining with event_event_group & audit_trail generates duplicate rows, hence the 'group by'
 GROUP BY anmEvt.ANIMAL_EVENT_ID,
@@ -27,6 +30,7 @@ GROUP BY anmEvt.ANIMAL_EVENT_ID,
          anmEvt.STAFF_ID.EMAIL_ADDRESS,
          anmEvt.EVENT_ID.NAME,
          anmEvt.TEXT_RESULT,
+         anmEvt.DIAGNOSIS,
          anmEvt.ATTACHMENT_PATH,
          anmCmt.TEXT,
          anmEvt.CREATED_DATETIME,

--- a/nirc_ehr/resources/queries/dbo/q_pregnancy_delete.sql
+++ b/nirc_ehr/resources/queries/dbo/q_pregnancy_delete.sql
@@ -1,0 +1,8 @@
+SELECT substring(adt.PRIMARY_KEY_VALUES, length('ANIMAL_EVENT_ID = ')) AS objectid,
+       CAST(adt.CHANGE_DATETIME AS TIMESTAMP)                            AS modified,
+       adt.REFERENCE
+FROM AUDIT_TRAIL adt
+WHERE adt.PRIMARY_KEY_VALUES LIKE '%ANIMAL_EVENT_ID%' AND
+    (adt.REFERENCE LIKE '%Stillborn Event%' OR
+     adt.REFERENCE LIKE '%Abort Event%') AND
+        adt.COLUMN_NAME = 'DELETE'

--- a/nirc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
+++ b/nirc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
@@ -9,6 +9,7 @@
     <datasets>
         <dataset name="arrival" id="1001" category="Colony Management" type="Standard"/>
         <dataset name="assignment" id="1002" category="Colony Management" type="Standard"/>
+        <dataset name="alopecia" id="1003" category="Colony Management" type="Standard"/>
         <dataset name="blood" id="1005" category="Clinical" type="Standard"/>
         <dataset name="birth" id="1007" category="Colony Management" demographicData="true" type="Standard"/>
         <dataset name="breeder" id="1008" category="Colony Management" type="Standard"/>

--- a/nirc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
+++ b/nirc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
@@ -28,6 +28,7 @@
         <dataset name="prc" id="1034" category="Clinical" type="Standard"/>
         <dataset name="protocolAssignment" id="1031" category="Colony Management" type="Standard"/>
         <dataset name="serology" id="1032" category="ClinPath" type="Standard"/>
+        <dataset name="pregnancy" id="1035" category="Reproductive Management" type="Standard"/>
         <dataset name="treatment_order" id="1014" category="Clinical" type="Standard"/>
         <dataset name="vitals" id="1033" category="Clinical" type="Standard"/>
         <dataset name="weight" id="1015" category="Clinical" type="Standard"/>

--- a/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -83,6 +83,36 @@
             </column>
         </columns>
     </table>
+    <table tableName="alopecia" tableDbType="TABLE">
+        <tableTitle>Alopecia</tableTitle>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="objectid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#ObjectId</propertyURI>
+                <isKeyField>true</isKeyField>
+            </column>
+            <column columnName="score">
+                <columnTitle>Score</columnTitle>
+                <datatype>integer</datatype>
+            </column>
+            <column columnName="diagnosis">
+                <columnTitle>Diagnosis</columnTitle>
+                <datatype>varchar</datatype>
+            </column>
+        </columns>
+    </table>
     <table tableName="protocolAssignment" tableDbType="TABLE">
         <tableTitle>Protocol Assignments</tableTitle>
         <columns>
@@ -655,6 +685,7 @@
                 <datatype>varchar</datatype>
             </column>
             <column columnName="diagnosis">
+                <columnTitle>Diagnosis</columnTitle>
                 <datatype>varchar</datatype>
             </column>
             <column columnName="attachmentFile">

--- a/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -193,12 +193,11 @@
                 <isKeyField>true</isKeyField>
             </column>
             <column columnName="type">
+                <columnTitle>Type</columnTitle>
                 <datatype>varchar</datatype>
             </column>
             <column columnName="result">
-                <datatype>varchar</datatype>
-            </column>
-            <column columnName="remark">
+                <columnTitle>Result</columnTitle>
                 <datatype>varchar</datatype>
             </column>
             <column columnName="attachmentFile">
@@ -231,9 +230,6 @@
                 <datatype>varchar</datatype>
             </column>
             <column columnName="hx">
-                <datatype>varchar</datatype>
-            </column>
-            <column columnName="remark">
                 <datatype>varchar</datatype>
             </column>
         </columns>
@@ -645,6 +641,10 @@
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
             </column>
+            <column columnName="enddate">
+                <datatype>timestamp</datatype>
+                <propertyURI>urn:ehr.labkey.org/#EndDate</propertyURI>
+            </column>
             <column columnName="objectid">
                 <datatype>varchar</datatype>
                 <propertyURI>urn:ehr.labkey.org/#ObjectId</propertyURI>
@@ -759,6 +759,44 @@
             </column>
             <column columnName="weight">
                 <datatype>double</datatype>
+            </column>
+        </columns>
+    </table>
+    <table tableName="pregnancy" tableDbType="TABLE">
+        <tableTitle>Pregnancy Outcomes</tableTitle>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="objectid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#ObjectId</propertyURI>
+                <isKeyField>true</isKeyField>
+            </column>
+            <column columnName="type">
+                <columnTitle>Type</columnTitle>
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="result">
+                <columnTitle>Result</columnTitle>
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="diagnosis">
+                <columnTitle>Diagnosis</columnTitle>
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="attachmentFile">
+                <columnTitle>Attachment File</columnTitle>
+                <datatype>varchar</datatype>
             </column>
         </columns>
     </table>


### PR DESCRIPTION
#### Rationale
Pregnancy Outcome and Alopecia ETLs and Animal History reports.  Handful of fixes from previous ETLs.

#### Changes
* Pregnancy Outcome and Alopecia incremental ETL with source and delete queries
* Add animal history reports and update some column titles
* Clinical Remarks and Breeding group by needed due to audit join duplicates
