### PR TITLE
Bump schema versions to 22.000

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -51,7 +51,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.023;
+        return 22.000;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We want all branches with active work to match their schema versions now that we're in 2022

#### Changes
* Update version to 22.000