### PR TITLE
Clean up study.xml files in referenceStudies

### DIFF
--- a/nirc_ehr/resources/referenceStudy/study.xml
+++ b/nirc_ehr/resources/referenceStudy/study.xml
@@ -4,11 +4,4 @@
     <datasets dir="datasets" file="datasets_manifest.xml">
         <definition file="PrimateElectronicHealthRecord.dataset"/>
     </datasets>
-    <comments/>
-    <missingValueIndicators>
-        <missingValueIndicator indicator="E" label="Value is estimated."/>
-        <missingValueIndicator indicator="Q" label="Data currently under quality control review."/>
-        <missingValueIndicator indicator="A" label="Data value is abnormal."/>
-        <missingValueIndicator indicator="N" label="Required field marked by site as 'data not available'."/>
-    </missingValueIndicators>
 </study>


### PR DESCRIPTION
#### Rationale
`<missingValueIndicators>` element is no longer supported in `study.xml`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2925