### PR TITLE
Remove study-archive-generating tasks

### DIFF
--- a/nirc_ehr/build.gradle
+++ b/nirc_ehr/build.gradle
@@ -15,25 +15,3 @@ dependencies
         }
 
 tasks.module.dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module)
-
-task('metadataStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset metadata") {
-    archiveFileName = 'nirc_study_metadata.zip'
-    destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-    from("resources/referenceStudy/") {
-        include "study.xml"
-        include "datasets/*"
-        exclude "datasets/*.tsv"
-    }
-}
-project.tasks.module.dependsOn(project.tasks.metadataStudyArchive)
-
-task('datasetStudyArchive', type: Zip, group: "Data", description: "Assemble study archive with dataset data") {
-    archiveFileName = 'nirc_study.zip'
-    destinationDirectory = project.file("${project.labkey.explodedModuleDir}/archives")
-    from("resources/referenceStudy/") {
-        include "study.xml"
-        include "datasets/*"
-    }
-}
-
-project.tasks.module.dependsOn(project.tasks.datasetStudyArchive)


### PR DESCRIPTION
#### Rationale
These tasks are no longer needed plus support for study archives is going away