### PR TITLE
Animal History case insensitive search

### DIFF
--- a/nirc_ehr/resources/queries/study/alias.sql
+++ b/nirc_ehr/resources/queries/study/alias.sql
@@ -1,10 +1,6 @@
 -- This query is used to match upper and lowercase names in animal history
 
 SELECT Id,
-       lower(Id) as alias
-FROM study.Animal
-UNION
-SELECT Id,
        Id as alias
 FROM study.Animal
 UNION

--- a/nirc_ehr/resources/web/nirc_ehr/panel/AnimalHistoryPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/AnimalHistoryPanel.js
@@ -70,7 +70,7 @@ Ext4.define('NIRC_EHR.panel.AnimalHistoryPanel', {
             inputValue: LDK.panel.SingleSubjectFilterType.filterName,
             label: 'Single Animal',
             nounSingular: 'Animal',
-            caseInsensitive: false,
+            caseInsensitive: true,
             aliasTable: {
                 schemaName: 'study',
                 queryName: 'alias',

--- a/nirc_ehr/resources/web/nirc_ehr/panel/AnimalHistoryPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/AnimalHistoryPanel.js
@@ -52,6 +52,7 @@ Ext4.define('NIRC_EHR.panel.AnimalHistoryPanel', {
             return [{
                 xtype: 'ehr-hiddensinglesubjectfiltertype',
                 inputValue: LDK.panel.SingleSubjectFilterType.filterName,
+                caseInsensitive: true,
                 aliasTable: {
                     schemaName: 'study',
                     queryName: 'alias',
@@ -69,6 +70,7 @@ Ext4.define('NIRC_EHR.panel.AnimalHistoryPanel', {
             inputValue: LDK.panel.SingleSubjectFilterType.filterName,
             label: 'Single Animal',
             nounSingular: 'Animal',
+            caseInsensitive: false,
             aliasTable: {
                 schemaName: 'study',
                 queryName: 'alias',
@@ -81,6 +83,7 @@ Ext4.define('NIRC_EHR.panel.AnimalHistoryPanel', {
             xtype: 'ehr-multianimalfiltertype',
             inputValue: EHR.panel.MultiAnimalFilterType.filterName,
             label: EHR.panel.MultiAnimalFilterType.label,
+            caseInsensitive: true,
             aliasTable: {
                 schemaName: 'study',
                 queryName: 'alias',


### PR DESCRIPTION
#### Rationale
Use Animal History case insensitive option.

#### Related Pull Requests
* https://github.com/LabKey/LabDevKitModules/pull/104

#### Changes
* Use caseInsensitive option for animal history
* Update alias query, lower case options no longer needed
