### PR TITLE
Numeric units, qualifier and vendor location

### DIFF
--- a/nirc_ehr/resources/data/lookup_sets.tsv
+++ b/nirc_ehr/resources/data/lookup_sets.tsv
@@ -18,3 +18,6 @@ termination_reason_codes	Termination Reason Codes Codes	value	title
 keyword	Keyword	value	title
 clinremarks_category	Clinremarks Category	value	title
 id_history_type	Id History Type	value	title
+qualifier	Qualifier	value	title
+vendor_production_location	Vendor Production Location	value	title
+numeric_unit	Numeric Units	value	title

--- a/nirc_ehr/resources/data/numeric_unit.tsv
+++ b/nirc_ehr/resources/data/numeric_unit.tsv
@@ -1,0 +1,91 @@
+value	title	description
+1	Kg	Kilogram
+2	mmol	Millimole
+3	mm	Millimeter
+4	mL/min	Milliliters per minute
+5	mL	Milliliter
+6	mg/L	Milligrams per liter
+7	mg/g	Milligrams per gram
+8	mg/dL	Milligrams per deciliter
+9	mg/d	Milligrams per day
+10	mg/24 hrs	Milligrams per 24 hours
+11	mg	Milligram
+12	mPOL	Milli polarization unit
+13	mIU/hr	Milli international units per hour
+14	mIU	Milli international units
+15	LIV	Lyme index value
+16	L	Liter
+17	IU/mL	International units per milliliter
+18	IU/L	International units per liter
+19	IU/g	International units per gram
+20	IU	International unit
+21	ISR	Immune status ratio
+22	MPL	IgM phospholipid units
+23	GPL	IgG phospholipid units
+24	h	Hour
+25	g/dL	Grams per deciliter
+26	g/d	Grams per day
+27	g/24 hrs	Grams per 24 hours
+28	g/5 hrs	Grams per 5hours
+29	g	Gram
+30	fL	Femtoliter
+31	EIU	Enzyme immunoassay unit
+32	EU/mL	Ehrlich units per milliliter
+33	EU/24 hrs	Ehrlich units per 24 hours
+34	EU	Ehrlich unit
+35	ETU/mL	Endotoxin units per milliliter
+36	dL	Deciliter
+37	d	Day
+38	cpy/mL	Copies per milliliter
+39	CMM	Cubic milliliter
+40	cP	Centipoise unit
+41	CFU/mL	Colony forming units per milliliter
+42	AU/mL	Arbitrary units per milliliter
+43	U/mL	Units per milliliter
+44	U/L	Units per liter
+45	U/hr	Units per hour
+46	U/g	Units per gram
+47	U/day	Units per day
+48	U	Unit
+49	TV	Total volume
+50	TIV	Toxoplasma index value
+51	SD	Standard deviation
+52	s	Second
+53	RIV	Rubella index value
+54	pmol/g	Picomoles per gram
+55	pmol	Picomole
+56	pg/mL	Picograms per milliliter
+57	pg	Picogram
+58	%	Percent
+59	ppm	Parts per million
+60	nmol/mL	Nanomoles per milliliter
+61	nmol/L	Nanomoles per liter
+62	nmol/g	Nanomoles per gram
+63	nmol/dL	Nanomoles per deciliter
+64	nmol/d	Nanomoles per day
+65	nmol	Nanomole
+66	nM/mM	Nanomole per millimole
+67	ng/mL/hr	Nanograms per milliliter per hour
+68	ng/mL	Nanograms per milliliter
+69	ng/L	Nanograms per liter
+70	ng/dL	Nanograms per deciliter
+71	ng	Nanogram
+72	mol	Mole
+73	min	Minute
+74	mU/mL	Milliunits per milliliter
+75	mU/L	Milliunits per liter
+76	mU/g	Milliunits per gram
+77	mU	Milliunit
+78	mOsm/kg	Milliosmoles per kilogram
+79	mOsm	Milliosmole
+80	mmol/L	Millimoles per liter
+81	mmol/d	Millimoles per day
+82	mmHg	Millimeters of Mercury
+83	p/m	Pulses per minute
+84	b/m	Breaths per minute
+85	hb/m	Heartbeats per minute
+86	°F	Degree Fahrenheit
+87	breaths/min	Breaths per minute
+88	heartbeats/min	Heartbeats per minute
+89	pulses/min	Pulses per minute
+90	BCS	Body condition score

--- a/nirc_ehr/resources/data/qualifier.tsv
+++ b/nirc_ehr/resources/data/qualifier.tsv
@@ -1,0 +1,54 @@
+value	title	description
+1	Species	Species
+2	Sex	Sex
+3	Age	Age
+4	Naive	Naive
+5	No Exposure to MAB	No Exposure to MAB
+6	No Exposure to other	No Exposure to other
+7	No Exposure to 30ds	No Exposure to 30ds
+8	No Exposure to 60ds	No Exposure to 60ds
+9	No Exposure to 90ds	No Exposure to 90ds
+10	No exposure for other	No exposure for other
+11	Juvenile	Juvenile
+12	HCV negative	HCV negative
+13	HIV negative	HIV negative
+14	HBV negative	HBV negative
+15	Monoclonal negative	Monoclonal negative
+16	HCV	HCV
+17	Antigenemia positive	Antigenemia positive
+18	SPF	SPF
+19	Enteric pathogen negative	Enteric pathogen negative
+20	Accepts alert dosing	Accepts alert dosing
+21	Alert bleeding	Alert bleeding
+22	Chair trained	Chair trained
+23	Obesity	Obesity
+24	Diabetes	Diabetes
+25	Male	Male
+26	Female	Female
+27	Over 2 years old	Over 2 years old
+28	Oophorectomized	Oophorectomized
+29	Vasectomy	Vasectomy
+30	Castration	Castration
+31	Hysterectomy	Hysterectomy
+32	Canines blunted	Canines blunted
+33	Canines removed	Canines removed
+34	Limb amputation	Limb amputation
+35	Abdominal Surgery (in the past)	Abdominal Surgery (in the past)
+36	SIB (under current medication)	Self Injurious Behavior  (under current medication)
+37	Chronic enteritis	Chronic enteritis
+38	Intermittent recurrent enteritis	Intermittent recurrent enteritis
+39	No experimental usage for 30days	No experimental usage for 30days
+40	Splenectomized	Splenectomized
+41	Partial hepatic lobectomy	Partial hepatic lobectomy
+42	Chronic disease	Chronic disease (may be heart disease, anything other than enteritis or diabetes)
+43	Alert bleeding trained	Alert bleeding trained
+44	Non-pregnant	Non-pregnant
+45	Lactating	Lactating
+46	Behavioral stereotypy (other than SIB)	Behavioral stereotypy (other than SIB)
+47	1 - 2 years old	1 - 2 years old
+48	Less than 1 year old	Less than 1 year old
+49	Nursing infant	Nursing infant
+50	Pregnant	Pregnant
+51	No Exposure for 30ds	No Exposure for 30ds
+52	No Exposure for 60ds	No Exposure for 60ds
+53	No Exposure for 90ds	No Exposure for 90ds

--- a/nirc_ehr/resources/data/vendor_production_location.tsv
+++ b/nirc_ehr/resources/data/vendor_production_location.tsv
@@ -1,0 +1,47 @@
+value	title	description
+1	Andover MA	4
+2	Pearl River NY	4
+3	Alice TX	4
+4	West Point PA	4
+5	Bethesda MD	4
+6	Bastrop TX	4
+7	San Antonio TX	4
+8	Homestead FL	4
+9	Atlanta GA	4
+10	Emeryville CA	4
+11	Waltham MA	4
+12	Columbus OH	4
+13	Italy	2
+14	Dickerson MD	4
+15	Bethesda MD	4
+16	Basseterre	1
+17	Yemassee SC	4
+18	Bethesda MD	4
+19	Makati City	5
+20	UL Lafayette - NIRC	4
+21	NIRC
+22	Columbus	4
+23	New York	4
+24	Yemassee	4
+25	Three Springs Scientific	4
+26	Sierra Biomedical	4
+27	NIH	4
+28	Lovelace Biomedical	4
+29	University of Washington NPRC	4
+30	"China/Guangxi Grand Forest Sci Primate "	4
+31	Charles River Laboratory	4
+33	Alamogordo Primate Facility	4
+34	Yale Univ Sch Medicine	4
+36	Cornell University Medical College	4
+37	Tulane NPC (Covington)	4
+38	CDC	4
+39	Covance, China	4
+42	St. Helena, SC	4
+44	MD Anderson Cancer Center	4
+45	University of Kentucky	4
+46	Wake Forest School of Medicine	4
+47	Hainan	7
+48	Cynologics Ltd	8
+49	Guangdong	7
+51	Mattawan, MI	4
+52	Phnom Penh	6

--- a/nirc_ehr/resources/queries/dbo/q_alopecia.sql
+++ b/nirc_ehr/resources/queries/dbo/q_alopecia.sql
@@ -7,12 +7,13 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.RESULT                                                             AS score,
        anmEvt.DIAGNOSIS                                                          AS diagnosis,
+       ev.NUMERIC_UNIT_ID                                                        AS Units,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
          LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
-
+         LEFT JOIN EVENT ev on anmEvt.EVENT_ID = ev.EVENT_ID
 WHERE anmEvt.EVENT_ID.EVENT_ID = 2293
   AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
 --     2293	Alopecia

--- a/nirc_ehr/resources/queries/dbo/q_animal_vendor.sql
+++ b/nirc_ehr/resources/queries/dbo/q_animal_vendor.sql
@@ -1,16 +1,18 @@
 SELECT
-    ANIMAL_VENDOR_ID            as AnimalVendorId,
-    VENDOR_APPROVAL_CODE_ID     as VendorApprovalCode,
-    VENDOR_Name                 as VendorName,
-    STREET_ADDRESS1             as StreetAddress1,
-    STREET_ADDRESS2             as StreetAddress2,
-    CITY                        as City,
-    STATE_PROV                  as StateProv,
-    COUNTRY                     as Country,
-    ZIP                         as Zip,
-    ZIP_EXT                     as ZipExt,
-    PHONE_NUMBER                as PhoneNumber,
-    FAX_NUMBER                  as FaxNumber,
-    COMMENTS                    as Comments,
-    INTERNAL_VENDOR_YN          as InternalVendor
-FROM ANIMAL_VENDOR
+    av.ANIMAL_VENDOR_ID            as AnimalVendorId,
+    av.VENDOR_APPROVAL_CODE_ID     as VendorApprovalCode,
+    av.VENDOR_Name                 as VendorName,
+    av.STREET_ADDRESS1             as StreetAddress1,
+    av.STREET_ADDRESS2             as StreetAddress2,
+    av.CITY                        as City,
+    av.STATE_PROV                  as StateProv,
+    av.COUNTRY                     as Country,
+    av.ZIP                         as Zip,
+    av.ZIP_EXT                     as ZipExt,
+    av.PHONE_NUMBER                as PhoneNumber,
+    av.FAX_NUMBER                  as FaxNumber,
+    av.COMMENTS                    as Comments,
+    av.INTERNAL_VENDOR_YN          as InternalVendor,
+    vpn.VENDOR_PRODUCTION_LOCATION_ID   as VendorProductionLocation
+FROM ANIMAL_VENDOR av
+LEFT JOIN VENDOR_PRODUCTION_LOCATION vpn ON av.ANIMAL_VENDOR_ID = vpn.ANIMAL_VENDOR_ID

--- a/nirc_ehr/resources/queries/dbo/q_blood.sql
+++ b/nirc_ehr/resources/queries/dbo/q_blood.sql
@@ -7,11 +7,13 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
        anmEvt.RESULT                                                             AS quantity,
+       ev.NUMERIC_UNIT_ID                                                        AS Units,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
          LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
+         LEFT JOIN EVENT ev ON anmEvt.EVENT_ID = ev.EVENT_ID
 
 WHERE anmEvt.EVENT_ID.EVENT_ID IN (1864, 1581)
   AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates

--- a/nirc_ehr/resources/queries/dbo/q_physicalExam.sql
+++ b/nirc_ehr/resources/queries/dbo/q_physicalExam.sql
@@ -8,12 +8,14 @@ SELECT anmEvt.ANIMAL_EVENT_ID as objectid,
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmCmt.TEXT AS remark,
        anmEvt.EVENT_ID.NAME AS exam,
-       anmEvt.RESULT
+       anmEvt.RESULT,
+       ev.NUMERIC_UNIT_ID                                                        AS Units
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
          LEFT JOIN EVENT_EVENT_GROUP evtEvtGrp ON evtEvtGrp.EVENT_ID = anmEvt.EVENT_ID
          LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
+         LEFT JOIN EVENT ev on anmEvt.EVENT_ID = ev.EVENT_ID
 WHERE evtEvtGrp.EVENT_GROUP_ID = 60 -- Physical Exam
   -- filter out vital signs events
   AND evtEvtGrp.EVENT_ID NOT IN (1349, 2165, 2166, 2167, 2168, 2169, 55, 56, 1643, 1647, 1652, 1653)

--- a/nirc_ehr/resources/queries/dbo/q_vitals.sql
+++ b/nirc_ehr/resources/queries/dbo/q_vitals.sql
@@ -13,11 +13,13 @@ SELECT anmEvt.ANIMAL_EVENT_ID as objectid,
        CASE WHEN anmEvt.EVENT_ID.NAME LIKE '%Pulse Rate%' THEN anmEvt.RESULT END AS pulseRate,
        CASE WHEN anmEvt.EVENT_ID.NAME LIKE '%Pulse Oximetry%' THEN anmEvt.RESULT END AS pulseOximetry,
        CASE WHEN anmEvt.EVENT_ID.NAME LIKE '%EKG%' THEN anmEvt.RESULT END AS ekg,
+       ev.NUMERIC_UNIT_ID AS Units,
        anmEvt.EVENT_ID.NAME AS type
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
          LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
+         LEFT JOIN EVENT ev on anmEvt.EVENT_ID = ev.EVENT_ID
 WHERE anmEvt.EVENT_ID.EVENT_ID IN (55, 56, 57, 1643, 1647, 1652, 1653, 1654, 1655, 2165, 2166, 2167, 2168, 2169)
   AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
         -- 55 Blood Pressure

--- a/nirc_ehr/resources/queries/dbo/q_weight.sql
+++ b/nirc_ehr/resources/queries/dbo/q_weight.sql
@@ -7,9 +7,11 @@ SELECT anmEvt.ANIMAL_EVENT_ID as objectid,
             WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
             ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
-       anmEvt.result AS weight
+       anmEvt.result AS weight,
+       ev.NUMERIC_UNIT_ID   AS Units
 FROM ANIMAL_EVENT anmEvt
 LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
+LEFT JOIN EVENT ev ON anmEvt.EVENT_ID = ev.EVENT_ID
 LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
 WHERE anmEvt.EVENT_ID = 1349 -- Body weight
   AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates

--- a/nirc_ehr/resources/queries/ehr_lookups/vendor_production_location.query.xml
+++ b/nirc_ehr/resources/queries/ehr_lookups/vendor_production_location.query.xml
@@ -1,0 +1,19 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="vendor_production_location" tableDbType="TABLE">
+                <columns>
+                    <column columnName="description">
+                        <columnTitle>Country</columnTitle>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>country</fkTable>
+                            <fkColumnName>value</fkColumnName>
+                            <fkDisplayColumnName>title</fkDisplayColumnName>
+                        </fk>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/nirc_ehr/resources/queries/nirc_ehr/AnimalVendor.query.xml
+++ b/nirc_ehr/resources/queries/nirc_ehr/AnimalVendor.query.xml
@@ -19,6 +19,15 @@
                     <column columnName="VendorName">
                         <columnTitle>Vendor Name</columnTitle>
                     </column>
+                    <column columnName="VendorProductionLocation">
+                        <columnTitle>Vendor Production Location</columnTitle>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>vendor_production_location</fkTable>
+                            <fkColumnName>value</fkColumnName>
+                            <fkDisplayColumnName>title</fkDisplayColumnName>
+                        </fk>
+                    </column>
                     <column columnName="StreetAddress1">
                         <columnTitle>Street Address 1</columnTitle>
                     </column>

--- a/nirc_ehr/resources/queries/nirc_ehr/AnimalVendor/.qview.xml
+++ b/nirc_ehr/resources/queries/nirc_ehr/AnimalVendor/.qview.xml
@@ -1,0 +1,20 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+    <columns>
+        <column name="AnimalVendorId" />
+        <column name="VendorApprovalCode" />
+        <column name="VendorName" />
+        <column name="VendorProductionLocation" />
+        <column name="StreetAddress1" />
+        <column name="StreetAddress2" />
+        <column name="City" />
+        <column name="StateProv" />
+        <column name="Country" />
+        <column name="Zip" />
+        <column name="ZipExt" />
+        <column name="PhoneNumber" />
+        <column name="FaxNumber" />
+        <column name="Comments" />
+        <column name="InternalVendor" />
+
+    </columns>
+</customView>

--- a/nirc_ehr/resources/queries/study/alopecia/.qview.xml
+++ b/nirc_ehr/resources/queries/study/alopecia/.qview.xml
@@ -5,12 +5,11 @@
     <columns>
         <column name="Id"/>
         <column name="date"/>
-        <column name="bloodPressure"/>
-        <column name="heartRate"/>
-        <column name="respRate"/>
-        <column name="temp"/>
-        <column name="pulseRate"/>
+        <column name="score"/>
         <column name="units"/>
-        <column name="type"/>
+        <column name="diagnosis"/>
+        <column name="remark"/>
+        <column name="performedBy"/>
+        <column name="history"/>
     </columns>
 </customView>

--- a/nirc_ehr/resources/queries/study/blood/.qview.xml
+++ b/nirc_ehr/resources/queries/study/blood/.qview.xml
@@ -5,12 +5,12 @@
     <columns>
         <column name="Id"/>
         <column name="date"/>
-        <column name="bloodPressure"/>
-        <column name="heartRate"/>
-        <column name="respRate"/>
-        <column name="temp"/>
-        <column name="pulseRate"/>
+        <column name="quantity"/>
         <column name="units"/>
         <column name="type"/>
+        <column name="remark"/>
+        <column name="countsAgainVolume"/>
+        <column name="performedBy"/>
+        <column name="history"/>
     </columns>
 </customView>

--- a/nirc_ehr/resources/queries/study/physicalExam/.qview.xml
+++ b/nirc_ehr/resources/queries/study/physicalExam/.qview.xml
@@ -7,6 +7,7 @@
         <column name="date"/>
         <column name="exam"/>
         <column name="result"/>
+        <column name="units"/>
         <column name="remark"/>
     </columns>
 </customView>

--- a/nirc_ehr/resources/queries/study/weight/.qview.xml
+++ b/nirc_ehr/resources/queries/study/weight/.qview.xml
@@ -5,12 +5,7 @@
     <columns>
         <column name="Id"/>
         <column name="date"/>
-        <column name="bloodPressure"/>
-        <column name="heartRate"/>
-        <column name="respRate"/>
-        <column name="temp"/>
-        <column name="pulseRate"/>
+        <column name="weight"/>
         <column name="units"/>
-        <column name="type"/>
     </columns>
 </customView>

--- a/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -109,6 +109,10 @@
                 <columnTitle>Diagnosis</columnTitle>
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="units">
+                <columnTitle>Units</columnTitle>
+                <datatype>integer</datatype>
+            </column>
         </columns>
     </table>
     <table tableName="biopsy" tableDbType="TABLE">
@@ -227,6 +231,10 @@
             </column>
             <column columnName="quantity">
                 <datatype>double</datatype>
+            </column>
+            <column columnName="units">
+                <columnTitle>Units</columnTitle>
+                <datatype>integer</datatype>
             </column>
         </columns>
     </table>
@@ -640,6 +648,10 @@
             <column columnName="result">
                 <datatype>double</datatype>
             </column>
+            <column columnName="units">
+                <columnTitle>Units</columnTitle>
+                <datatype>integer</datatype>
+            </column>
             <column columnName="remark">
                 <datatype>varchar</datatype>
             </column>
@@ -871,6 +883,10 @@
                 <columnTitle>Type</columnTitle>
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="units">
+                <columnTitle>Units</columnTitle>
+                <datatype>integer</datatype>
+            </column>
         </columns>
         <tableTitle>Vital Signs</tableTitle>
     </table>
@@ -896,6 +912,10 @@
             </column>
             <column columnName="weight">
                 <datatype>double</datatype>
+            </column>
+            <column columnName="units">
+                <columnTitle>Units</columnTitle>
+                <datatype>integer</datatype>
             </column>
         </columns>
     </table>

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.006-22.007.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.006-22.007.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nirc_ehr.AnimalVendor ADD COLUMN VendorProductionLocation INTEGER;

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.006-22.007.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.006-22.007.sql
@@ -1,1 +1,15 @@
 ALTER TABLE nirc_ehr.AnimalVendor ADD COLUMN VendorProductionLocation INTEGER;
+
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;lookup_sets;/data/lookup_sets.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;qualifier;/data/qualifier.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;numeric_unit;/data/numeric_unit.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;vendor_production_location;/data/vendor_production_location.tsv');
+
+SELECT core.executeJavaUpgradeCode('reloadStudy');
+
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/alopecia;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/blood;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/vitals;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/physicalExam;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/weight;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/animalVendor;truncate');

--- a/nirc_ehr/resources/schemas/nirc_ehr.xml
+++ b/nirc_ehr/resources/schemas/nirc_ehr.xml
@@ -267,6 +267,7 @@
             <column columnName="FaxNumber"/>
             <column columnName="Comments"/>
             <column columnName="InternalVendor"/>
+            <column columnName="VendorProductionLocation"/>
             <column columnName="Container"/>
             <column columnName="Created"/>
             <column columnName="CreatedBy"/>

--- a/nirc_ehr/resources/views/populateData.html
+++ b/nirc_ehr/resources/views/populateData.html
@@ -126,6 +126,24 @@
             schemaName: 'ehr_lookups',
             queryName: 'id_history_type',
             pk: 'value'
+        }, {
+            label: 'Numeric Units',
+            populateFn: 'populateFromFile',
+            schemaName: 'ehr_lookups',
+            queryName: 'numeric_unit',
+            pk: 'value'
+        }, {
+            label: 'Vendor Production Location',
+            populateFn: 'populateFromFile',
+            schemaName: 'ehr_lookups',
+            queryName: 'vendor_production_location',
+            pk: 'value'
+        }, {
+            label: 'Qualifier',
+            populateFn: 'populateFromFile',
+            schemaName: 'ehr_lookups',
+            queryName: 'qualifier',
+            pk: 'value'
         }];
 
         tables.sort(function(a, b) {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -52,7 +52,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.006;
+        return 22.007;
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
@@ -96,6 +96,12 @@ public class NIRC_EHRCustomizer extends AbstractTableCustomizer
             {
                 col.setLabel("Description");
             }
+            if ("units".equalsIgnoreCase(col.getName()) && null == col.getFk())
+            {
+                UserSchema us = getEHRUserSchema(ti, "ehr_lookups");
+                col.setLabel("Units");
+                col.setFk(new QueryForeignKey(ti.getUserSchema(), ti.getContainerFilter(), us, null, "numeric_unit", "value", "title"));
+            }
         }
     }
 


### PR DESCRIPTION
#### Rationale
Numeric units, qualifier and vendor production location data migration

#### Changes
* Add Numeric_Units, Qualifier and Vendor_Production_Location TSV lookups
* Add vendorProductionLocation to AnimalVendor table and ETL. Setup FK.
* Add NumericUnits to blood, alopecia, vitals, physicalExam and weight datasets and ETLs. Setup FKs.