### PR TITLE
Remove unused <categories> elements from datasets_manifest.xml files in sample archives

### DIFF
--- a/nirc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
+++ b/nirc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>Clinical</category>
-        <category>ClinPath</category>
-        <category>Colony Management</category>
-        <category>Pathology</category>
-    </categories>
     <datasets>
         <dataset name="arrival" id="1001" category="Colony Management" type="Standard"/>
         <dataset name="assignment" id="1002" category="Colony Management" type="Standard"/>


### PR DESCRIPTION
#### Rationale
Support for unused `<categories>` element has been removed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062