### PR TITLE
Fix housing trigger script

### DIFF
--- a/nirc_ehr/resources/queries/study/housing.js
+++ b/nirc_ehr/resources/queries/study/housing.js
@@ -13,7 +13,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
     }
 
         if (row.endDate === 'undefined') {
-            console.log("end date not found for animal event - " + row.objectId);
+            console.log("Housing end date not found for animal event - " + row.objectId);
         }
 
         prevAnimalId = row.Id;

--- a/nirc_ehr/resources/queries/study/housing.js
+++ b/nirc_ehr/resources/queries/study/housing.js
@@ -4,19 +4,66 @@ var prevDate;
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'housing', function (helper, scriptErrors, row, oldRow) {
 
-    var isTransfer = prevAnimalId === row.Id;
+    if (helper.isETL()) {
+        var isTransfer = prevAnimalId === row.Id;
 
-    if (isTransfer) {
-        row.endDate = prevDate;
+        if (isTransfer) {
+            row.endDate = prevDate;
+        }
     }
 
-    if (row.endDate === 'undefined') {
-        console.log("end date not found for animal event - " + row.objectId);
+        if (row.endDate === 'undefined') {
+            console.log("end date not found for animal event - " + row.objectId);
+        }
+
+        prevAnimalId = row.Id;
+        prevDate = row.date;
+    });
+
+function onComplete(event, errors, helper){
+
+    // Similar to EHR housing trigger onComplete with minor differences to handle ETL
+    var idsToClose = [];
+    if (helper.isETL()) {
+        var boundaryRows = helper.getRows();
+        if (boundaryRows && boundaryRows.length > 0) {
+            boundaryRows = [boundaryRows[0]];  // Just need first boundary row for this extra step
+            for (var i = 0; i < boundaryRows.length; i++) {
+                if (EHR.Server.Security.getQCStateByLabel(boundaryRows[i].row.QCStateLabel).PublicData && boundaryRows[i].row.date) {
+                    boundaryRows[i].row.date.setHours(12);  // This just prevents warnings in EHR
+                    idsToClose.push({
+                        Id: boundaryRows[i].row.Id,
+                        date: EHR.Server.Utils.datetimeToString(boundaryRows[i].row.date),  //stringify to serialize properly
+                        objectid: boundaryRows[i].row.objectid
+                    });
+                }
+            }
+        }
     }
 
-    prevAnimalId = row.Id;
-    prevDate = row.date;
+    else if (!helper.isValidateOnly()) {
+        var housingRows = helper.getRows();
+        if (housingRows && housingRows.length > 0) {
+            console.log("count: " + housingRows.length);
+            housingRows = [housingRows[0]]
+            for (var i = 0; i < housingRows.length; i++) {
+                console.log("id: " + housingRows[i].row.Id);
+                console.log("date: " + EHR.Server.Utils.datetimeToString(housingRows[i].row.date))
+                if (EHR.Server.Security.getQCStateByLabel(housingRows[i].row.QCStateLabel).PublicData && housingRows[i].row.date) {
+                    housingRows[i].row.date.setHours(12);
+                    idsToClose.push({
+                        Id: housingRows[i].row.Id,
+                        date: EHR.Server.Utils.datetimeToString(housingRows[i].row.date),  //stringify to serialize properly
+                        objectid: housingRows[i].row.objectid
+                    });
+                }
+            }
+        }
+    }
 
-});
+    if (idsToClose.length){
+        helper.getJavaHelper().closeHousingRecords(idsToClose);
+    }
+};
 
 

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.008-22.009.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.008-22.009.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/housing;truncate');

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -52,7 +52,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.008;
+        return 22.009;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The housing trigger script is correctly setting the outdate from previous consecutive rows, however when separated by batches or for incremental uploads, there is a break in the data which misses the outdate at the boundary of the ETL.

#### Changes
* Add onComplete handling of boundary rows similar to the EHR housing trigger. Closes out the previous row using the EHR trigger Java helper.
* Add onComplete handling for manual entry while we're at it, since overriding the EHR trigger.
