### PR TITLE
Housing incremental filter and attachment updates

### DIFF
--- a/nirc_ehr/resources/queries/dbo/q_biopsy.sql
+++ b/nirc_ehr/resources/queries/dbo/q_biopsy.sql
@@ -6,7 +6,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
             ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile,
        anmEvt.DIAGNOSIS                                                          AS description,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified

--- a/nirc_ehr/resources/queries/dbo/q_breeder.sql
+++ b/nirc_ehr/resources/queries/dbo/q_breeder.sql
@@ -7,7 +7,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
        anmEvt.TEXT_RESULT                                                        AS result,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt

--- a/nirc_ehr/resources/queries/dbo/q_cases.sql
+++ b/nirc_ehr/resources/queries/dbo/q_cases.sql
@@ -9,7 +9,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
        anmCmt.TEXT                                                               AS remark,
        anmEvt.DIAGNOSIS                                                          AS diagnosis,
        anmEvt.EVENT_ID.NAME                                                      AS category,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN staffInfo staff ON staff.staff_id = anmEvt.STAFF_ID
          LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID

--- a/nirc_ehr/resources/queries/dbo/q_drug.sql
+++ b/nirc_ehr/resources/queries/dbo/q_drug.sql
@@ -7,7 +7,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
        anmEvt.RESULT                                                             AS amount,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt

--- a/nirc_ehr/resources/queries/dbo/q_necropsy.sql
+++ b/nirc_ehr/resources/queries/dbo/q_necropsy.sql
@@ -8,7 +8,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID as objectid,
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmCmt.TEXT AS remark,
        anmEvt.EVENT_ID.NAME AS category,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+            ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+       ELSE NULL END AS attachmentFile
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID

--- a/nirc_ehr/resources/queries/dbo/q_notes.sql
+++ b/nirc_ehr/resources/queries/dbo/q_notes.sql
@@ -6,7 +6,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
             ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
                 || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS type,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP)        AS modified
 FROM ANIMAL_EVENT anmEvt

--- a/nirc_ehr/resources/queries/dbo/q_pregnancy.sql
+++ b/nirc_ehr/resources/queries/dbo/q_pregnancy.sql
@@ -8,7 +8,10 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
        anmEvt.EVENT_ID.NAME                                                      AS type,
        anmEvt.TEXT_RESULT                                                        AS result,
        anmEvt.DIAGNOSIS                                                          AS diagnosis,
-       anmEvt.ATTACHMENT_PATH                                                    AS attachmentFile,
+       CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
+                ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
+                    || substring(anmEvt.ATTACHMENT_PATH, LENGTH('N:\'), LENGTH(anmEvt.ATTACHMENT_PATH)))
+            ELSE NULL END AS attachmentFile,
        anmCmt.TEXT                                                               AS remark,
        CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP) AS modified
 FROM ANIMAL_EVENT anmEvt

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.013-22.014.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.013-22.014.sql
@@ -1,0 +1,8 @@
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/necropsy;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/biopsy;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/breeder;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/drug;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/cases;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/pregnancy;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/notes;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/housing;truncate');

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -58,7 +58,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.013;
+        return 22.014;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
- Housing trigger script has an issue when incremental ETL fires.  
- Attachment paths should be transformed on import to match file root.

#### Changes
- Housing trigger update to account for incremental ETL.
- Attachment path transform in query to hard-coded file root path
