### PR TITLE
Don't try to truncate multi-step ETL

### DIFF
--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.015-22.016.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.015-22.016.sql
@@ -7,7 +7,6 @@ SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/pairings;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/physicalExam;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/prc;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/pregnancy;truncate');
-SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocolAssignment;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/serology;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/vitals;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/weight;truncate');

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.015-22.016.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.015-22.016.sql
@@ -11,5 +11,7 @@ SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocolAssignment;truncate')
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/serology;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/vitals;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/weight;truncate');
-SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/ProtocolAndAssignment;truncate');
-SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/ProjectAndAssignment;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/project;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/assignment;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocol;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocolAssignment;truncate');


### PR DESCRIPTION
#### Rationale
Truncate won't work on the multi-step ETLs. Update to single step ETLs.

#### Changes
* Update startup script... again
