### PR TITLE
Project and protocol assignment ETL updates

### DIFF
--- a/nirc_ehr/resources/etls/assignment.xml
+++ b/nirc_ehr/resources/etls/assignment.xml
@@ -7,19 +7,11 @@
             <description>Copy to assignment target</description>
             <source schemaName="dbo" queryName="q_assignment"/>
             <destination schemaName="study" queryName="assignment"
-                         bulkLoad="true" batchSize="5000" targetOption="merge">
+                         bulkLoad="true" batchSize="5000" targetOption="truncate">
                 <columnTransforms>
                     <column source="assignmentDate" target="date"/>
                 </columnTransforms>
-                <alternateKeys>
-                    <column name="objectid"/>
-                </alternateKeys>
             </destination>
         </transform>
     </transforms>
-
-    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" >
-        <deletedRowsSource schemaName="dbo" queryName="q_assignment_delete" timestampColumnName="modified"
-                           deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
-    </incrementalFilter>
 </etl>

--- a/nirc_ehr/resources/etls/protocolAssignment.xml
+++ b/nirc_ehr/resources/etls/protocolAssignment.xml
@@ -7,10 +7,7 @@
             <description>Copy to assignment target</description>
             <source schemaName="dbo" queryName="q_protocolAssignment"/>
             <destination schemaName="study" queryName="protocolAssignment"
-                         bulkLoad="true" batchSize="5000" targetOption="merge">
-                <alternateKeys>
-                    <column name="objectid"/>
-                </alternateKeys>
+                         bulkLoad="true" batchSize="5000" targetOption="truncate">
                 <columnTransforms>
                     <column source="transferDate" target="date"/>
                     <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>

--- a/nirc_ehr/resources/queries/dbo/q_assignment.sql
+++ b/nirc_ehr/resources/queries/dbo/q_assignment.sql
@@ -4,13 +4,16 @@ SELECT alt.ALTERNATE_ID AS "objectId",
        alt.NAME AS "projectName",
        alt.NAME AS "description",
        ae.EVENT_DATETIME AS assignmentDate,  -- Set to arrival/birth then updated by trigger
-       COALESCE(alt.DESCRIPTION, CAST(ae.EVENT_DATETIME AS VARCHAR(100))) AS "changeDateText",
+       CASE WHEN alt.DESCRIPTION IS NULL OR length(trim(alt.DESCRIPTION)) != 11 THEN NULL
+       ELSE COALESCE(TO_DATE(alt.DESCRIPTION, 'DD-Mon-RR'), COALESCE(dea.deathDate, dep.eventDate)) END as endDate,
        COALESCE(MAX(CAST(adt.CHANGE_DATETIME AS TIMESTAMP)), ae.CREATED_DATETIME) AS modified
 FROM  ALTERNATE alt
 LEFT JOIN ANIMAL anm ON alt.ANIMAL_ID = anm.ANIMAL_ID
 LEFT JOIN AUDIT_TRAIL adt ON alt.ALTERNATE_ID = substring(PRIMARY_KEY_VALUES, length('Alternate_ID = '))
     AND adt.TABLE_NAME = 'ALTERNATE'
 LEFT JOIN ANIMAL_EVENT ae ON ae.ANIMAL_ID = anm.ANIMAL_ID AND EVENT_ID = 1  -- Received
+LEFT JOIN q_deaths dea ON anm.ANIMAL_ID_NUMBER = dea.participantId
+LEFT JOIN q_departure dep ON anm.ANIMAL_ID_NUMBER = dep.Id
 WHERE alt.ALTERNATE_TYPE_ID = 6 -- Project Inventory Number for project transfers
 GROUP BY alt.ALTERNATE_ID,
          anm.ANIMAL_ID,
@@ -18,5 +21,7 @@ GROUP BY alt.ALTERNATE_ID,
          alt.NAME,
          alt.DESCRIPTION,
          ae.CREATED_DATETIME,
-         ae.EVENT_DATETIME
+         ae.EVENT_DATETIME,
+         dea.deathDate,
+         dep.eventDate
 ORDER BY anm.ANIMAL_ID,alt.ALTERNATE_ID ASC

--- a/nirc_ehr/resources/queries/dbo/q_assignment.sql
+++ b/nirc_ehr/resources/queries/dbo/q_assignment.sql
@@ -13,7 +13,7 @@ LEFT JOIN AUDIT_TRAIL adt ON alt.ALTERNATE_ID = substring(PRIMARY_KEY_VALUES, le
     AND adt.TABLE_NAME = 'ALTERNATE'
 LEFT JOIN ANIMAL_EVENT ae ON ae.ANIMAL_ID = anm.ANIMAL_ID AND EVENT_ID = 1  -- Received
 LEFT JOIN q_deaths dea ON anm.ANIMAL_ID_NUMBER = dea.participantId
-LEFT JOIN q_departure dep ON anm.ANIMAL_ID_NUMBER = dep.Id
+LEFT JOIN q_latestDeparture dep ON anm.ANIMAL_ID_NUMBER = dep.Id
 WHERE alt.ALTERNATE_TYPE_ID = 6 -- Project Inventory Number for project transfers
 GROUP BY alt.ALTERNATE_ID,
          anm.ANIMAL_ID,

--- a/nirc_ehr/resources/queries/dbo/q_departure.sql
+++ b/nirc_ehr/resources/queries/dbo/q_departure.sql
@@ -1,21 +1,28 @@
 -- Used for departure ETL. There are some duplicate departures in ANIMAL_EVENTS thus the GROUP BY and MAX values
-SELECT MAX(anmEvt.ANIMAL_EVENT_ID) AS objectid,
-       anm.ANIMAL_ID_NUMBER  AS Id,
-       anm.ANIMAL_DISPOSITION_ID AS destination,
-       CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP) AS eventDate,
-       evt.NAME AS description,
-       (CASE
-            WHEN (MAX(anmEvt.STAFF_ID.STAFF_FIRST_NAME) IS NULL OR MAX(anmEvt.STAFF_ID.STAFF_LAST_NAME) IS NULL) THEN 'unknown'
-            ELSE (MAX(anmEvt.STAFF_ID.STAFF_FIRST_NAME)
-                || '|' || MAX(anmEvt.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
-       CAST(COALESCE(MAX(adt.modified), MAX(anmEvt.CREATED_DATETIME)) AS TIMESTAMP)           AS modified
-FROM ANIMAL_EVENT anmEvt
-LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
-LEFT JOIN EVENT evt ON anmEvt.EVENT_ID = evt.EVENT_ID
-LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
-WHERE anmEvt.EVENT_ID IN (SELECT EVENT_ID FROM EVENT WHERE NAME LIKE 'Lab Transfer To%')
-GROUP BY
-    anm.ANIMAL_ID_NUMBER,
-    anm.ANIMAL_DISPOSITION_ID,
-    anmEvt.EVENT_DATETIME,
-    evt.NAME
+SELECT
+    i.*,
+   (CASE
+        WHEN (st.STAFF_FIRST_NAME IS NULL OR
+              st.STAFF_LAST_NAME IS NULL) THEN 'unknown'
+        ELSE (st.STAFF_FIRST_NAME
+            || '|' || st.STAFF_LAST_NAME) END)                AS performedby
+FROM
+(
+   SELECT MAX(anmEvt.ANIMAL_EVENT_ID)                                                  AS objectid,
+          anm.ANIMAL_ID_NUMBER                                                         AS Id,
+          anm.ANIMAL_DISPOSITION_ID                                                    AS destination,
+          CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP)                                     AS eventDate,
+          evt.NAME                                                                     AS description,
+          MAX(anmEvt.STAFF_ID)                                                         AS staff,
+          CAST(COALESCE(MAX(adt.modified), MAX(anmEvt.CREATED_DATETIME)) AS TIMESTAMP) AS modified
+   FROM ANIMAL_EVENT anmEvt
+            LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
+            LEFT JOIN EVENT evt ON anmEvt.EVENT_ID = evt.EVENT_ID
+            LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
+   WHERE anmEvt.EVENT_ID IN (SELECT EVENT_ID FROM EVENT WHERE NAME LIKE 'Lab Transfer To%')
+   GROUP BY anm.ANIMAL_ID_NUMBER,
+            anm.ANIMAL_DISPOSITION_ID,
+            anmEvt.EVENT_DATETIME,
+            evt.NAME
+) i
+LEFT JOIN STAFF st ON i.staff = st.STAFF_ID

--- a/nirc_ehr/resources/queries/dbo/q_departure.sql
+++ b/nirc_ehr/resources/queries/dbo/q_departure.sql
@@ -1,16 +1,21 @@
--- Used for departure ETL and in q_status.sql
-SELECT anmEvt.ANIMAL_EVENT_ID AS objectid,
+-- Used for departure ETL. There are some duplicate departures in ANIMAL_EVENTS thus the GROUP BY and MAX values
+SELECT MAX(anmEvt.ANIMAL_EVENT_ID) AS objectid,
        anm.ANIMAL_ID_NUMBER  AS Id,
        anm.ANIMAL_DISPOSITION_ID AS destination,
        CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP) AS eventDate,
        evt.NAME AS description,
        (CASE
-            WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
-            ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
-                || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
-       CAST(COALESCE(adt.modified, anmEvt.CREATED_DATETIME) AS TIMESTAMP)           AS modified
+            WHEN (MAX(anmEvt.STAFF_ID.STAFF_FIRST_NAME) IS NULL OR MAX(anmEvt.STAFF_ID.STAFF_LAST_NAME) IS NULL) THEN 'unknown'
+            ELSE (MAX(anmEvt.STAFF_ID.STAFF_FIRST_NAME)
+                || '|' || MAX(anmEvt.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
+       CAST(COALESCE(MAX(adt.modified), MAX(anmEvt.CREATED_DATETIME)) AS TIMESTAMP)           AS modified
 FROM ANIMAL_EVENT anmEvt
 LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
 LEFT JOIN EVENT evt ON anmEvt.EVENT_ID = evt.EVENT_ID
 LEFT JOIN q_modified_event adt ON anmEvt.ANIMAL_EVENT_ID = adt.event_id
 WHERE anmEvt.EVENT_ID IN (SELECT EVENT_ID FROM EVENT WHERE NAME LIKE 'Lab Transfer To%')
+GROUP BY
+    anm.ANIMAL_ID_NUMBER,
+    anm.ANIMAL_DISPOSITION_ID,
+    anmEvt.EVENT_DATETIME,
+    evt.NAME

--- a/nirc_ehr/resources/queries/dbo/q_latestDeparture.sql
+++ b/nirc_ehr/resources/queries/dbo/q_latestDeparture.sql
@@ -1,0 +1,12 @@
+
+-- Used in assignment queries. Handles duplicates and multiple departures.
+SELECT d.* FROM
+q_departure d
+INNER JOIN
+(
+    SELECT
+    q_departure.Id,
+    MAX(q_departure.eventDate) as latest,
+    FROM q_departure
+    GROUP BY Id
+) l ON d.Id = l.Id AND d.eventDate = l.latest

--- a/nirc_ehr/resources/queries/dbo/q_protocolAssignment.sql
+++ b/nirc_ehr/resources/queries/dbo/q_protocolAssignment.sql
@@ -3,6 +3,7 @@ SELECT anmEvt.ANIMAL_EVENT_ID AS "objectId",
        anmEvt.ANIMAL_EVENT_ID AS "animalEventId",
        anm.ANIMAL_ID_NUMBER AS Id,
        CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP) AS transferDate,
+       COALESCE(dea.deathDate, dep.eventDate) AS enddate,
        (CASE
             WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
             ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
@@ -12,6 +13,8 @@ SELECT anmEvt.ANIMAL_EVENT_ID AS "objectId",
 FROM ANIMAL_EVENT anmEvt
          LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
          LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
+         LEFT JOIN q_deaths dea ON anm.ANIMAL_ID_NUMBER = dea.participantId
+         LEFT JOIN q_departure dep ON anm.ANIMAL_ID_NUMBER = dep.Id
 WHERE anmEvt.EVENT_ID = 2 --Animal Transfer
   AND anmCmt.TEXT LIKE '%Pro%'
   ORDER BY anm.ANIMAL_ID_NUMBER,anmEvt.ANIMAL_EVENT_ID DESC

--- a/nirc_ehr/resources/queries/dbo/q_protocolAssignment.sql
+++ b/nirc_ehr/resources/queries/dbo/q_protocolAssignment.sql
@@ -1,20 +1,47 @@
-
-SELECT anmEvt.ANIMAL_EVENT_ID AS "objectId",
-       anmEvt.ANIMAL_EVENT_ID AS "animalEventId",
-       anm.ANIMAL_ID_NUMBER AS Id,
-       CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP) AS transferDate,
-       COALESCE(dea.deathDate, dep.eventDate) AS enddate,
-       (CASE
-            WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
+SELECT * FROM
+(
+    SELECT
+        anmEvt.ANIMAL_EVENT_ID                                   AS "objectId",
+        anmEvt.ANIMAL_EVENT_ID                                   AS "animalEventId",
+        anm.ANIMAL_ID_NUMBER                                     AS Id,
+        CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP)                 AS transferDate,
+        COALESCE(dea.deathDate, dep.eventDate)                   AS enddate,
+        (CASE
+            WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL)
+                THEN 'unknown'
             ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
-                || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
-       REPLACE(anmCmt.TEXT, ';', ':') AS remark,
-       anmEvt.LOCATION_ID AS location
-FROM ANIMAL_EVENT anmEvt
-         LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
-         LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
-         LEFT JOIN q_deaths dea ON anm.ANIMAL_ID_NUMBER = dea.participantId
-         LEFT JOIN q_departure dep ON anm.ANIMAL_ID_NUMBER = dep.Id
-WHERE anmEvt.EVENT_ID = 2 --Animal Transfer
-  AND anmCmt.TEXT LIKE '%Pro%'
-  ORDER BY anm.ANIMAL_ID_NUMBER,anmEvt.ANIMAL_EVENT_ID DESC
+                || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END) AS performedby,
+        REPLACE(anmCmt.TEXT, ';', ':')                           AS remark,
+        anmEvt.LOCATION_ID                                       AS location
+  FROM ANIMAL_EVENT anmEvt
+       LEFT JOIN ANIMAL anm ON anmEvt.ANIMAL_ID = anm.ANIMAL_ID
+       LEFT JOIN ANIMAL_EVENT_COMMENT anmCmt ON anmEvt.ANIMAL_EVENT_ID = anmCmt.ANIMAL_EVENT_ID
+       LEFT JOIN q_deaths dea ON anm.ANIMAL_ID_NUMBER = dea.participantId
+       LEFT JOIN q_latestDeparture dep ON anm.ANIMAL_ID_NUMBER = dep.Id
+  WHERE anmEvt.EVENT_ID = 2 --Animal Transfer
+    AND anmCmt.TEXT LIKE '%Pro%'
+
+  UNION
+
+  SELECT
+      ae.ANIMAL_EVENT_ID                                   as objectId,
+      ae.ANIMAL_EVENT_ID                                   as animalEventId,
+      an.ANIMAL_ID_NUMBER                    as Id,
+      CAST(ae.EVENT_DATETIME AS TIMESTAMP)                      as transferDate,
+      COALESCE(dea.deathDate, dep.eventDate) AS enddate,
+      (CASE
+           WHEN (ae.STAFF_ID.STAFF_FIRST_NAME IS NULL OR ae.STAFF_ID.STAFF_LAST_NAME IS NULL)
+               THEN 'unknown'
+           ELSE (ae.STAFF_ID.STAFF_FIRST_NAME
+               || '|' || ae.STAFF_ID.STAFF_LAST_NAME) END) AS performedby,
+      'From Protocol: None: To Protocol: ' || pr.PROTOCOL_NUMBER            as remark,
+      ae.LOCATION_ID                                   as location
+  FROM ANIMAL an
+       JOIN CAGE_CARD cc ON an.CAGE_CARD_ID = cc.CAGE_CARD_ID
+       JOIN SEGMENT se ON cc.SEGMENT_ID = se.SEGMENT_ID
+       JOIN PROTOCOL pr ON se.PROTOCOL_ID = pr.PROTOCOL_ID
+       LEFT JOIN ANIMAL_EVENT ae ON ae.ANIMAL_ID = an.ANIMAL_ID AND EVENT_ID = 1 -- Received
+       LEFT JOIN q_deaths dea ON an.ANIMAL_ID_NUMBER = dea.participantId
+       LEFT JOIN q_latestDeparture dep ON an.ANIMAL_ID_NUMBER = dep.Id
+) a
+ORDER BY a.Id,a.transferDate DESC

--- a/nirc_ehr/resources/queries/study/assignment.js
+++ b/nirc_ehr/resources/queries/study/assignment.js
@@ -4,59 +4,54 @@ var prevAnimalId;
 var prevDate;
 
 function onInit(event, helper){
-    LABKEY.Query.selectRows({
-        schemaName: 'ehr',
-        queryName: 'project',
-        columns: 'project,name',
-        success: function(results){
-            if (results.rows.length){
-                for (var i = 0; i < results.rows.length; i++) {
-                    let rec = results.rows[i];
-                    projectData[rec.name] = rec.project;
+    if (helper.isETL()) {
+        LABKEY.Query.selectRows({
+            schemaName: 'ehr',
+            queryName: 'project',
+            columns: 'project,name',
+            success: function (results) {
+                if (results.rows.length) {
+                    for (var i = 0; i < results.rows.length; i++) {
+                        let rec = results.rows[i];
+                        projectData[rec.name] = rec.project;
+                    }
                 }
-            }
-        },
-        scope: this
-    });
+            },
+            scope: this
+        });
+    }
 }
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'assignment', function (helper, scriptErrors, row, oldRow) {
 
-    // use enddate of previous assignment otherwise animal birth/arrival will be in row.date
-    if (prevAnimalId === row.Id) {
-        row.date = prevDate;
-    }
-
-    if (row.changeDateText) {
-        if (row.changeDateText.indexOf("ACQ:") === 0) {
-            row.endDate = new Date(Date.parse(row.changeDateText.split(":")[1].trim()));
+    if (helper.isETL()) {
+        // use enddate of previous assignment otherwise animal birth/arrival will be in row.date
+        if (prevAnimalId === row.Id) {
+            row.date = prevDate;
         }
-        else {
-            row.endDate = new Date(Date.parse(row.changeDateText));
-        }
-    }
 
-    var projectName = row.projectName.split(' ')[0];
-    var projectId = projectData[projectName];
-    if (!projectId) {
-        var projectNames = Object.keys(projectData);
-        for (var i = 0; i< projectNames.length; i++) {
+        var projectName = row.projectName.split(' ')[0];
+        var projectId = projectData[projectName];
+        if (!projectId) {
+            var projectNames = Object.keys(projectData);
+            for (var i = 0; i < projectNames.length; i++) {
 
-            var pName = projectNames[i] ;
-            if (pName.toString().indexOf(projectName) === 0) {
-                projectId = projectData[projectNames[i]];
+                var pName = projectNames[i];
+                if (pName.toString().indexOf(projectName) === 0) {
+                    projectId = projectData[projectNames[i]];
+                }
             }
         }
-    }
-    if (projectId) {
-        row.project = projectId;
-    }
-    else {
-        console.log("project can not be found - ", projectName);
-    }
-    prevAnimalId = row.Id;
-    if (!(!row.endDate || row.endDate === 'undefined')) {
-        prevDate = row.endDate;
+        if (projectId) {
+            row.project = projectId;
+        }
+        else {
+            console.log("project can not be found - ", projectName);
+        }
+        prevAnimalId = row.Id;
+        if (!(!row.endDate || row.endDate === 'undefined')) {
+            prevDate = row.endDate;
+        }
     }
 
 });

--- a/nirc_ehr/resources/queries/study/protocolAssignment.js
+++ b/nirc_ehr/resources/queries/study/protocolAssignment.js
@@ -6,50 +6,65 @@ var prevDate;
 var missing = [];
 
 function onInit(event, helper){
-    LABKEY.Query.selectRows({
-        schemaName: 'ehr',
-        queryName: 'protocol',
-        columns: 'title,objectid',
-        success: function(results){
-            if (results.rows.length){
-                for (var i = 0; i < results.rows.length; i++) {
-                    let rec = results.rows[i];
-                    protocolData[rec.objectid]  = rec.title;
+    if (helper.isETL()) {
+        LABKEY.Query.selectRows({
+            schemaName: 'ehr',
+            queryName: 'protocol',
+            columns: 'title,objectid',
+            success: function (results) {
+                if (results.rows.length) {
+                    for (var i = 0; i < results.rows.length; i++) {
+                        let rec = results.rows[i];
+                        protocolData[rec.objectid] = rec.title;
+                    }
                 }
-            }
-        },
-        scope: this
-    });
+            },
+            scope: this
+        });
+    }
 }
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'protocolAssignment', function (helper, scriptErrors, row, oldRow) {
 
-    var isTransfer = prevAnimalId === row.Id;
+    if (helper.isETL()) {
+        var isTransfer = prevAnimalId === row.Id;
 
-    if (row.remark) {
-        var remarkTextArr = row.remark.split(':');
-        var toProtocol = remarkTextArr[3].split(' (')[0]; // Get "To Protocol:" value without segment
-        var protocolId;
+        if (row.remark) {
+            var remarkTextArr = row.remark.split(':');
+            var toProtocol = remarkTextArr[3].split(' (')[0]; // Get "To Protocol:" value without segment
+            var protocolId;
 
-        protocolId = getProtocolIdByName(toProtocol);
-        if (!protocolId || protocolId === 'undefined') {
-            if (missing.indexOf(toProtocol) === -1)
-                missing.push(toProtocol)
-        }
-        else {
-            row.protocol = protocolId;
-        }
-        if (isTransfer) {
-            row.endDate = prevDate;
+            protocolId = getProtocolIdByName(toProtocol);
+            if (!protocolId || protocolId === 'undefined') {
+                if (missing.indexOf(toProtocol) === -1)
+                    missing.push(toProtocol)
+            }
+            else {
+                row.protocol = protocolId;
+            }
+            if (isTransfer) {
+                if (row.enddate) {
+                    // End date will initially have animal death/departure. Override if the transfer is older.
+                    var death = new Date(row.enddate);
+                    var prev = new Date(prevDate);
+
+                    if (prev < death) {
+                        row.enddate = prevDate;
+                    }
+                }
+                else {
+                    row.enddate = prevDate;
+                }
+            }
+
+            if (row.enddate === 'undefined') {
+                console.log("end date not found for animal event - " + row.animalEventId);
+            }
         }
 
-        if (row.endDate === 'undefined') {
-            console.log("end date not found for animal event - " + row.animalEventId);
-        }
+        prevAnimalId = row.Id;
+        prevDate = row.date;
     }
-
-    prevAnimalId = row.Id;
-    prevDate = row.date;
 
 });
 

--- a/nirc_ehr/resources/queries/study/protocolAssignment.js
+++ b/nirc_ehr/resources/queries/study/protocolAssignment.js
@@ -6,33 +6,25 @@ var prevDate;
 var missing = [];
 
 var count = 0;
-var batchLastDate;
 
 function getLastAssignment(id){
+    var batchLastDate;
+
     LABKEY.Query.selectRows({
         schemaName: 'study',
         queryName: 'protocolAssignment',
         columns: 'Id,date',
         filterArray: [LABKEY.Filter.create('Id', id)],
+        sort: '-date',
         success: function (results) {
             if (results.rows.length) {
-                for (var i = 0; i < results.rows.length; i++) {
-                    let rec = results.rows[i];
-                    if (!batchLastDate) {
-                        batchLastDate = rec.date;
-                    }
-                    else {
-                        var oldDate = new Date(batchLastDate);
-                        var newDate = new Date(rec.date);
-                        if (newDate > oldDate) {
-                            batchLastDate = rec.date;
-                        }
-                    }
-                }
+                batchLastDate = results.rows[0].date;
             }
         },
         scope: this
     });
+
+    return batchLastDate;
 }
 
 function onInit(event, helper){
@@ -90,7 +82,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
             else if (count === 0) {
                 // This handles batch boundary row for full truncate ETL, which is the only ETL setup for this currently.
                 // Gets previous date from db for first row in batch
-                getLastAssignment(row.Id);
+                var batchLastDate = getLastAssignment(row.Id);
                 if (batchLastDate) {
                     row.enddate = batchLastDate;
                 }

--- a/nirc_ehr/resources/queries/study/protocolAssignment.js
+++ b/nirc_ehr/resources/queries/study/protocolAssignment.js
@@ -91,13 +91,8 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
                 // This handles batch boundary row for full truncate ETL, which is the only ETL setup for this currently.
                 // Gets previous date from db for first row in batch
                 getLastAssignment(row.Id);
-                console.log("Batch boundary id - " + row.Id);
                 if (batchLastDate) {
-                    console.log("Batch boundary date from previous row - " + batchLastDate);
                     row.enddate = batchLastDate;
-                }
-                else {
-                    console.log("Batch boundary date from existing row - " + row.enddate);
                 }
             }
 

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
@@ -1,2 +1,3 @@
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/departure;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/assignment;truncate');
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocolAssignment;truncate');

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/assignment;truncate');

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-22.017-22.018.sql
@@ -1,1 +1,2 @@
 SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/assignment;truncate');
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/protocolAssignment;truncate');

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -58,7 +58,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.017;
+        return 22.018;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Project and protocol enddate updates, including date parsing fix and using departure/death dates.  Fix some issues with departures for use as an enddate. Due to complexity of getting the data, switch assignments and protocolAssignment ETLs to truncate.

#### Changes
* Move assignment date parsing from JS trigger to SQL
* COALESCE on death and departure dates for protocol and project enddates
* Update departure query to handle duplicates
* Add q_latestDeparture to get last departure of an animal
* Union in the first protocol assignment via cage card -> segment -> protocol
* Handle previous row dates/enddates across batch boundaries for protocol and project assignments
* Convert protocol and project ETLs to truncate ETLs
