### PR TITLE
MHC dataset, ETL and module dependencies update

### DIFF
--- a/nirc_ehr/build.gradle
+++ b/nirc_ehr/build.gradle
@@ -12,6 +12,9 @@ dependencies
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ldap", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premium", depProjectConfig: "published", depExtension: "module")
+            BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:professional", depProjectConfig: "published", depExtension: "module")
         }
 
 tasks.module.dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module)

--- a/nirc_ehr/resources/etls/cases.xml
+++ b/nirc_ehr/resources/etls/cases.xml
@@ -23,8 +23,4 @@
         <deletedRowsSource schemaName="dbo" queryName="q_cases_delete" timestampColumnName="modified"
                            deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
     </incrementalFilter>
-
-    <schedule>
-        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
-    </schedule>
 </etl>

--- a/nirc_ehr/resources/etls/deaths.xml
+++ b/nirc_ehr/resources/etls/deaths.xml
@@ -22,7 +22,4 @@
         <deletedRowsSource schemaName="dbo" queryName="q_deaths_delete" timestampColumnName="modified"
                            deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
     </incrementalFilter>
-    <schedule>
-        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
-    </schedule>
 </etl>

--- a/nirc_ehr/resources/etls/departure.xml
+++ b/nirc_ehr/resources/etls/departure.xml
@@ -23,8 +23,4 @@
         <deletedRowsSource schemaName="dbo" queryName="q_departure_delete" timestampColumnName="modified"
                            deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
     </incrementalFilter>
-
-    <schedule>
-        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
-    </schedule>
 </etl>

--- a/nirc_ehr/resources/etls/ehrRecords.xml
+++ b/nirc_ehr/resources/etls/ehrRecords.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>EHR Records</name>
+    <description>Housing, cases, notes, departures and deaths</description>
+    <transforms>
+        <transform id="step 1" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.di.steps.QueueJobTask">
+                <settings>
+                    <setting name="transformId" value="{NIRC_EHR}/housing"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step 2" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.di.steps.QueueJobTask">
+                <settings>
+                    <setting name="transformId" value="{NIRC_EHR}/cases"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step 3" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.di.steps.QueueJobTask">
+                <settings>
+                    <setting name="transformId" value="{NIRC_EHR}/notes"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step 4" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.di.steps.QueueJobTask">
+                <settings>
+                    <setting name="transformId" value="{NIRC_EHR}/departure"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step 5" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.di.steps.QueueJobTask">
+                <settings>
+                    <setting name="transformId" value="{NIRC_EHR}/deaths"/>
+                </settings>
+            </taskref>
+        </transform>
+    </transforms>
+    <schedule>
+        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
+    </schedule>
+</etl>

--- a/nirc_ehr/resources/etls/housing.xml
+++ b/nirc_ehr/resources/etls/housing.xml
@@ -23,8 +23,4 @@
         <deletedRowsSource schemaName="dbo" queryName="q_housing_delete" timestampColumnName="modified"
                            deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
     </incrementalFilter>
-
-    <schedule>
-        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
-    </schedule>
 </etl>

--- a/nirc_ehr/resources/etls/notes.xml
+++ b/nirc_ehr/resources/etls/notes.xml
@@ -23,8 +23,4 @@
         <deletedRowsSource schemaName="dbo" queryName="q_notes_delete" timestampColumnName="modified"
                            deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
     </incrementalFilter>
-
-    <schedule>
-        <cron expression="0 0 20 * * ?" /> <!--Run at 8PM every day-->
-    </schedule>
 </etl>

--- a/nirc_ehr/resources/queries/study/MHC.query.xml
+++ b/nirc_ehr/resources/queries/study/MHC.query.xml
@@ -1,0 +1,14 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="housing" tableDbType="TABLE">
+                <columns>
+                    <column columnName="QCState">
+                        <shownInUpdateView>false</shownInUpdateView>
+                        <shownInInsertView>false</shownInInsertView>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/nirc_ehr/resources/web/ehr/metadata/Default.js
+++ b/nirc_ehr/resources/web/ehr/metadata/Default.js
@@ -1,0 +1,16 @@
+
+
+EHR.model.DataModelManager.registerMetadata('Default', {
+    byQuery: {
+        'study.MHC': {
+            QCState: {
+                getInitialValue: function(v){
+                    var qc;
+                    if (!v && EHR.Security.getQCStateByLabel('Completed'))
+                        qc = EHR.Security.getQCStateByLabel('Completed').RowId;
+                    return v || qc;
+                },
+            }
+        }
+    }
+});

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -82,6 +82,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
         addController(NIRC_EHRController.NAME, NIRC_EHRController.class);
 
         EHRService ehrService = EHRService.get();
+        ehrService.registerClientDependency(ClientDependency.supplierFromPath("ehr/metadata/Default.js"), this);
         ehrService.registerClientDependency(ClientDependency.supplierFromPath("nirc_ehr/nircReports.js"), this);
         ehrService.registerClientDependency(ClientDependency.supplierFromPath("nirc_ehr/panel/SnapshotPanel.js"), this);
         ehrService.registerClientDependency(ClientDependency.supplierFromPath("nirc_ehr/panel/BloodSummaryPanel.js"), this);


### PR DESCRIPTION
#### Rationale
- Allow entry into MHC dataset as Completed qc state
- Due to dependencies closing out records on death and departure, create multi-step ETL for handful of dependent ETLs
- Update gradle dependencies for dev environment

#### Changes
* Make MHC qc state not show in update forms and set default value to Completed
* Create mult-step ETL for housing, cases, notes, departures and deaths
* Add ldap, premium and professional module dependencies