### PR TITLE
Update cases ETL error handling

### DIFF
--- a/nirc_ehr/resources/queries/nirc_ehr/casesSource.sql
+++ b/nirc_ehr/resources/queries/nirc_ehr/casesSource.sql
@@ -11,4 +11,4 @@ SELECT objectid,
        category,
        attachmentFile
 FROM CasesTemp
-WHERE category = 'Presenting Diagnosis'
+WHERE category = 'Presenting Diagnosis' AND (openRemark IS NULL OR openRemark NOT LIKE 'Error:%')

--- a/nirc_ehr/resources/schemas/nirc_ehr.xml
+++ b/nirc_ehr/resources/schemas/nirc_ehr.xml
@@ -569,7 +569,7 @@
         </columns>
     </table>
     <table tableName="CasesTemp" tableDbType="TABLE">
-        <tableTitle>Cases Staging For ETl</tableTitle>
+        <tableTitle>Cases Staging For ETL</tableTitle>
         <columns>
             <column columnName="Id"/>
             <column columnName="date"/>


### PR DESCRIPTION
#### Rationale
Mark all instances of inconsistencies in source data due to consecutive Presenting Diagnosis or Clinical Resolution. These two animal event categories should alternate as cases are opened and closed. Also fix an issue parsing case closed date on death/departure.

#### Changes
* Change casesTemp trigger to EHR triggers for access to EHR.Server.Utils.datetimeToString.
* Properly parse death/departure dates for case closed.
* Mark all consecutive Presenting Diagnosis or Clinical Resolutions as errors in openRemark.
* Don't ETL Error cases into cases dataset.
