### PR TITLE
Sort cases ETL source by date

### DIFF
--- a/nirc_ehr/resources/queries/dbo/q_cases.sql
+++ b/nirc_ehr/resources/queries/dbo/q_cases.sql
@@ -30,4 +30,4 @@ SELECT * FROM (
           OR anmEvt.EVENT_ID = 1677 -- 1580 Presenting Diagnosis, 1677 Clinical Resolution
            AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
       ) cas
-ORDER BY cas.Id, cas.objectid DESC
+ORDER BY cas.Id, cas.caseDate DESC


### PR DESCRIPTION
#### Rationale
Initially the cases ETL source sort was by animal event id but that is not entirely chronological with the cases. This updates to sort by animal event date.

#### Changes
* Update q_cases.sql order by columns
