### PR TITLE
Update cases etl source ordering and don't do batches

### DIFF
--- a/nirc_ehr/resources/etls/cases.xml
+++ b/nirc_ehr/resources/etls/cases.xml
@@ -7,7 +7,7 @@
             <description>Copy to cases temp table</description>
             <source schemaName="dbo" queryName="q_cases"/>
             <destination schemaName="nirc_ehr" queryName="CasesTemp"
-                         bulkLoad="true" batchSize="5000" targetOption="truncate">
+                         bulkLoad="true" targetOption="truncate">
                 <columnTransforms>
                     <column source="caseDate" target="date"/>
                     <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>

--- a/nirc_ehr/resources/queries/dbo/q_cases.sql
+++ b/nirc_ehr/resources/queries/dbo/q_cases.sql
@@ -30,4 +30,4 @@ SELECT * FROM (
           OR anmEvt.EVENT_ID = 1677 -- 1580 Presenting Diagnosis, 1677 Clinical Resolution
            AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
       ) cas
-ORDER BY cas.Id, cas.caseDate DESC
+ORDER BY cas.Id DESC, cas.caseDate DESC, cas.category ASC

--- a/nirc_ehr/resources/queries/nirc_ehr/casesTemp.js
+++ b/nirc_ehr/resources/queries/nirc_ehr/casesTemp.js
@@ -1,37 +1,6 @@
 require("ehr/triggers").initScript(this);
-var console = require("console");
-var LABKEY = require("labkey");
-
 
 var prevRow;
-
-EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'nirc_ehr', 'casesTemp', function(event, helper) {
-    // Get boundary rows for ETL batches. Trigger will lose scope between batches so need to load up previous row from
-    // prior batch.
-    if (helper.isETL()) {
-        LABKEY.Query.executeSql({
-            schemaName: 'nirc_ehr',
-            sql: "SELECT Id, date, category FROM nirc_ehr.casesTemp ORDER BY objectid DESC LIMIT 1",
-            maxRows: 1,
-            scope: this,
-            failure: LABKEY.Utils.getCallbackWrapper(function (response) {
-                if (response && response.errors) {
-                    console.log("Error querying boundary case: " + response.errors);
-                }
-            }),
-            success: function (results) {
-                if (results.rows && results.rows.length > 0) {
-
-                    var resultRow = results.rows[0];
-                    prevRow = {};
-                    prevRow.category = resultRow.category;
-                    prevRow.Id = resultRow.Id;
-                    prevRow.date = resultRow.date;
-                }
-            }
-        });
-    }
-});
 
 function getEnddate(row, enddate){
     var closeDate = new Date(enddate);


### PR DESCRIPTION
#### Rationale
Still some discrepancies in the results of the cases ETL. This refines the ordering further, similar to a query used at the center. Remove batches from ETL.

#### Changes
* Update q_cases ordering to include category
* Remove batchSize from ETL
* Remove batch boundary handling from trigger script
