### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/nirc_ehr/build.gradle
+++ b/nirc_ehr/build.gradle
@@ -17,4 +17,4 @@ dependencies
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:professional", depProjectConfig: "published", depExtension: "module")
         }
 
-tasks.module.dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module)
+tasks.named('module').configure { dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module) }


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration