### PR TITLE
migrate snapshotPanel inline handler

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/nirc_ehr_api.lib.xml
+++ b/nirc_ehr/resources/web/nirc_ehr/nirc_ehr_api.lib.xml
@@ -1,5 +1,6 @@
 <libraries xmlns="http://labkey.org/clientLibrary/xml/">
     <library compileInProductionMode="false">
         <script path="nirc_ehr/model/sources/NIRCDefault.js"/>
+        <script path="nirc_ehr/utils.js"/>
     </library>
 </libraries>

--- a/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
@@ -16,7 +16,7 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
         this.on('afterrender', function() {
 
             var displayField = this.down('#flags');
-            if (displayField.getEl()) {
+            if (displayField && displayField.getEl()) {
 
                 var anchor = displayField.getEl('nircFlagsLink');
 

--- a/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
@@ -2,6 +2,34 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
     extend: 'EHR.panel.SnapshotPanel',
     alias: 'widget.nirc_ehr-snapshotpanel',
 
+    initComponent: function() {
+        Ext4.apply(this, {
+            defaults: {
+                border: false
+            },
+            items: this.getItems()
+        });
+
+        this.callParent();
+
+
+        this.on('afterrender', function() {
+
+            var displayField = this.down('#flags');
+            if (displayField.getEl()) {
+
+                var anchor = displayField.getEl('nircFlagsLink');
+
+                if (anchor) {
+                    Ext4.get(anchor).on('click', function(e) {
+                        e.preventDefault();
+                        NIRC_EHR.Utils.showFlagPopup(this.subjectId, this);
+                    });
+                }
+            }
+        });
+    },
+
     appendDemographicsResults: function(toSet, row, id){
         if (!row){
             console.log('Id not found');
@@ -73,7 +101,7 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
             }
         }
 
-        toSet['flags'] = values.length ? '<a onclick="NIRC_EHR.Utils.showFlagPopup(\'' + LABKEY.Utils.encodeHtml(this.subjectId) + '\', this);">' + values.join('<br>') + '</div>' : null;
+        toSet['flags'] = values.length ? '<a id="nircFlagsLink">' + values.join('<br>') + '</div>' : null;
     }
 
 });


### PR DESCRIPTION
#### Rationale
A strict (no 'unsafe-inline' directive) CSP forbids all inline events. Instead, events must be attached via JavaScript inside a properly nonced script tag

#### Changes
* snapshotpanel.js
