### PR TITLE
Add scriptNonce in datasets.html

### DIFF
--- a/nirc_ehr/resources/views/datasets.html
+++ b/nirc_ehr/resources/views/datasets.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
 Ext4.onReady(function () {
     var webpart = <%=webpartContext%>;


### PR DESCRIPTION
#### Rationale
Every HTML script tag requires a nonce with a value that matching the request-specific value in the response CSP header.

