### PR TITLE
Clinical Case Data Entry - initial iteration

### DIFF
--- a/nirc_ehr/resources/data/editable_lookups.tsv
+++ b/nirc_ehr/resources/data/editable_lookups.tsv
@@ -29,6 +29,8 @@ necropsy_specimen_condition	Colony Management	Necropsy Specimen Condition
 necropsy_tissue	Colony Management	Necropsy Tissue
 numeric_unit	Colony Management	Numeric Unit
 pregnancy_result	Colony Management	Pregancy Result
+problem_list_category	Clinical	Problem List Category	Used in problem list dataset. Set when opening a case.
+problem_list_subcategory	Clinical	Problem List Subcategory	Used in problem list to categorize problems.
 protocol_category	Colony Management	Protocol Category
 protocol_state	Colony Management	Protocol State
 protocol_type	Colony Management	Protocol Type

--- a/nirc_ehr/resources/data/lookup_sets.tsv
+++ b/nirc_ehr/resources/data/lookup_sets.tsv
@@ -27,6 +27,8 @@ necropsy_specimen_condition	Specimen Condition	value	title
 necropsy_tissue	Tissues	value	title
 numeric_unit	Numeric Units	value	title
 pregnancy_result	Pregnancy Results	value
+problem_list_category	Problem List Category	value
+problem_list_subcategory	Problem List Sub-Category	value
 protocol_category	Protocol Category	value	title
 protocol_state	Protocol State	value	title
 protocol_type	Protocol Type	value	title

--- a/nirc_ehr/resources/data/lookupsManifest.tsv
+++ b/nirc_ehr/resources/data/lookupsManifest.tsv
@@ -30,6 +30,8 @@ necropsy_specimen_condition
 necropsy_tissue
 numeric_unit
 pregnancy_result
+problem_list_category
+problem_list_subcategory
 protocol_category
 protocol_state
 protocol_type

--- a/nirc_ehr/resources/data/lookupsManifestTest.tsv
+++ b/nirc_ehr/resources/data/lookupsManifestTest.tsv
@@ -30,6 +30,8 @@ necropsy_specimen_condition
 necropsy_tissue
 numeric_unit
 pregnancy_result
+problem_list_category
+problem_list_subcategory
 protocol_category
 protocol_state
 protocol_type

--- a/nirc_ehr/resources/data/problem_list_category.tsv
+++ b/nirc_ehr/resources/data/problem_list_category.tsv
@@ -1,0 +1,21 @@
+value	description
+Behavioral	Behavioral issue or concern. Examples include SIB and fecal smearing.
+Cardiac Abnormality	Abnormalities associated with the cardiac system. Examples include murmurs and dilated cardiomyopathy.
+Dermatopathy	Abnormalities associated with the dermal system. Examples include alopecia and moist dermatitis. 
+Endocrinopathy	Abnormalities associated with the endocrine system. Diabetes is an example.
+GI-Diarrhea	Clinical cases presenting for diarrhea, with or without dehydration. 
+GI-Other	Abnormalities associated with the digestive system, excluding diarrhea. Examples include dental extractions, vomiting, and adenocarcinoma.
+MS Abnormality	Abnormalities associated with the musculoskeletal system. Examples include osteoarthritis, reactive arthritis, and fractures.
+Neurologic Abnormality	Abnormalities associated with the neurologic system. Seizures are an example.
+OBGYN Condition	Abnormalities associated with the female reproductive system. Examples include dystocia, vaginal prolapse, and heavy mense.
+Ophthalmic Abnormality	Abnormalities associated with the ophthalmic system. Examples include blepharospasm and corneal abrasion.
+Other	For conditions not covered by any other Master Problem. Uncommonly used.
+Protocol Associated	The primary abnormality is the result of experimental manipulation. Examples include implant abscess, induced anemia, and induced diabetes mellitus.
+Research Support	The case was opened for a surgery or activity supporting a research project. Examples include lymph node biopsy and BAL.
+Respiratory Abnormality	Abnormalities associated with the respiratory system. Examples include URI and pneumonia.
+Routine or Preventative care	Cases opened for routine or preventative care. Physical exam is an example.
+Urogenital	Abnormalities associated with the urogenital system. Examples include cystitis, testicular or vulvar trauma, or renal amyloidosis.
+Weight Loss	Cases opened for weight loss, when the etiology is unknown.
+Weight Management	
+Wound	Cases opened for a wound. 
+Monitoring	This is used to track animals that need additional monitoring after the initial problem has resolved.  This allows the initial problem to be closed while still keeping an active case open.

--- a/nirc_ehr/resources/data/problem_list_subcategory.tsv
+++ b/nirc_ehr/resources/data/problem_list_subcategory.tsv
@@ -1,0 +1,19 @@
+value	category
+Weight Loss	Weight Management
+Weight Gain	Weight Management
+Dental	GI-Other
+Vomiting	GI-Other
+Liver	GI-Other
+Alopecia	Behavioral
+SIB	Behavioral
+Other	Behavioral
+Stereotypy	Behavioral
+Fecal smear	Behavioral
+Eye poking	Behavioral
+Urine drinking	Behavioral
+Copraphagy	Behavioral
+Minor Laceration/Abrasion	Wound
+Digit Amputation	Wound
+Muscle Wound, Minor	Wound
+Muscle Wound, Major	Wound
+Rhabdomyolysis	Wound

--- a/nirc_ehr/resources/queries/dbo/q_cases.sql
+++ b/nirc_ehr/resources/queries/dbo/q_cases.sql
@@ -6,14 +6,14 @@ SELECT * FROM (
           (CASE
                WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL)
                    THEN 'unknown'
-               ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
-                   || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)               AS performedby,
+               ELSE (trim(anmEvt.STAFF_ID.STAFF_FIRST_NAME)
+                   || '|' || trim(anmEvt.STAFF_ID.STAFF_LAST_NAME)) END)               AS performedby,
           (CASE WHEN anmEvt.EVENT_ID = 1580 THEN anmCmt.TEXT ELSE NULL END)      AS openRemark,
           (CASE WHEN anmEvt.EVENT_ID = 1677 THEN anmCmt.TEXT ELSE NULL END)      AS closeRemark,
           (CASE WHEN anmEvt.EVENT_ID = 1580 THEN anmEvt.DIAGNOSIS ELSE NULL END) AS openDiagnosis,
           (CASE WHEN anmEvt.EVENT_ID = 1677 THEN anmEvt.DIAGNOSIS ELSE NULL END) AS closeDiagnosis,
           COALESCE(dea.deathDate, dep.eventDate)                                 AS enddate,
-          anmEvt.EVENT_ID.NAME                                                   AS category,
+          anmEvt.EVENT_ID.NAME                                                   AS caseCategory,
           CASE
               WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
                   ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'
@@ -30,4 +30,4 @@ SELECT * FROM (
           OR anmEvt.EVENT_ID = 1677 -- 1580 Presenting Diagnosis, 1677 Clinical Resolution
            AND anmEvt.CREATED_DATETIME < now() -- there are rows in ANIMAL_EVENT table with future dates
       ) cas
-ORDER BY cas.Id DESC, cas.caseDate DESC, cas.category ASC
+ORDER BY cas.Id DESC, cas.caseDate DESC, cas.caseCategory ASC

--- a/nirc_ehr/resources/queries/dbo/q_observations.sql
+++ b/nirc_ehr/resources/queries/dbo/q_observations.sql
@@ -3,8 +3,8 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
        CAST(anmEvt.EVENT_DATETIME AS TIMESTAMP)                                  AS obsDate,
        (CASE
             WHEN (anmEvt.STAFF_ID.STAFF_FIRST_NAME IS NULL OR anmEvt.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
-            ELSE (anmEvt.STAFF_ID.STAFF_FIRST_NAME
-                || '|' || anmEvt.STAFF_ID.STAFF_LAST_NAME) END)                  AS performedby,
+            ELSE (trim(anmEvt.STAFF_ID.STAFF_FIRST_NAME)
+                || '|' || trim(anmEvt.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
        anmEvt.EVENT_ID.NAME                                                      AS category,
        anmCmt.TEXT                                                               AS remark,
        anmEvt.DIAGNOSIS                                                          AS diagnosis,

--- a/nirc_ehr/resources/queries/study/activeTreatmentOrders.sql
+++ b/nirc_ehr/resources/queries/study/activeTreatmentOrders.sql
@@ -17,4 +17,4 @@ SELECT
     description,
     remark
 FROM treatment_order
-WHERE isActive = true
+WHERE enddate IS NULL OR enddate >= NOW() -- calculated col. isActive is false when the enddate is in the future, so using this condition instead

--- a/nirc_ehr/resources/queries/study/cases.query.xml
+++ b/nirc_ehr/resources/queries/study/cases.query.xml
@@ -1,0 +1,72 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="cases" tableDbType="TABLE" useColumnOrder="true">
+                <tableUrl></tableUrl>
+                <insertUrl />
+                <importUrl />
+                <updateUrl />
+                <deleteUrl />
+                <columns>
+                    <column columnName="Id"/>
+                    <column columnName="date">
+                        <columnTitle>Open Date</columnTitle>
+                        <formatString>Date</formatString>
+                    </column>
+                    <column columnName="enddate">
+                        <columnTitle>Close Date</columnTitle>
+                        <isHidden>false</isHidden>
+                    </column>
+                    <column columnName="problemCategory">
+                        <columnTitle>Problem Area</columnTitle>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>problem_list_category</fkTable>
+                            <fkColumnName>value</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="problemSubcategory">
+                        <columnTitle>Problem Subcategory</columnTitle>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>problem_list_subcategory</fkTable>
+                            <fkColumnName>value</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="openRemark">
+                        <inputType>textarea</inputType>
+                        <inputRows>5</inputRows>
+                    </column>
+                    <column columnName="plan">
+                        <columnTitle>Case Plan</columnTitle>
+                        <inputType>textarea</inputType>
+                        <inputRows>5</inputRows>
+                    </column>
+                    <column columnName="closeRemark">
+                        <inputType>textarea</inputType>
+                        <inputRows>5</inputRows>
+                    </column>
+                    <column columnName="performedby">
+                        <columnTitle>Opened By</columnTitle>
+                    </column>
+                    <column columnName="category">
+                        <columnTitle>Category</columnTitle>
+                        <isUserEditable>false</isUserEditable>
+                        <nullable>false</nullable>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>data_category</fkTable>
+                            <fkColumnName>value</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="project">
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="remark">
+                        <isHidden>true</isHidden>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
@@ -571,6 +571,10 @@
             <column columnName="enddate">
                 <datatype>timestamp</datatype>
             </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
+            </column>
         </columns>
     </table>
     <table tableName="inbreeding" tableDbType="TABLE">

--- a/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
@@ -255,6 +255,10 @@
                 <columnTitle>Units</columnTitle>
                 <datatype>integer</datatype>
             </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
+            </column>
         </columns>
     </table>
     <table tableName="breeder" tableDbType="TABLE">
@@ -805,6 +809,10 @@
             <column columnName="type">
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
+            </column>
         </columns>
     </table>
     <table tableName="serology" tableDbType="TABLE">
@@ -936,6 +944,9 @@
                 <propertyURI>urn:ehr.labkey.org/#EndDate</propertyURI>
             </column>
             <column columnName="category">
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="caseCategory">
                 <columnTitle>Case category</columnTitle>
                 <datatype>varchar</datatype>
             </column>
@@ -959,6 +970,27 @@
                 <columnTitle>Attachment File</columnTitle>
                 <datatype>varchar</datatype>
                 <rangeURI>http://cpas.fhcrc.org/exp/xml#fileLink</rangeURI>
+            </column>
+            <column columnName="problemCategory">
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="problemSubcategory">
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="plan">
+                <datatype>varchar</datatype>
+            </column>
+            <column columnName="vetreview">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#VetReview</propertyURI>
+            </column>
+            <column columnName="vetreviewdate">
+                <datatype>timestamp</datatype>
+                <propertyURI>urn:ehr.labkey.org/#VetReviewDate</propertyURI>
+            </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
             </column>
         </columns>
     </table>
@@ -1016,6 +1048,10 @@
             <column columnName="category">
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
+            </column>
         </columns>
     </table>
     <table tableName="vitals" tableDbType="TABLE">
@@ -1060,6 +1096,10 @@
                 <columnTitle>Units</columnTitle>
                 <datatype>integer</datatype>
             </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
+            </column>
         </columns>
         <tableTitle>Vital Signs</tableTitle>
     </table>
@@ -1084,6 +1124,10 @@
             <column columnName="units">
                 <columnTitle>Units</columnTitle>
                 <datatype>integer</datatype>
+            </column>
+            <column columnName="caseid">
+                <datatype>varchar</datatype>
+                <propertyURI>urn:ehr.labkey.org/#CaseId</propertyURI>
             </column>
         </columns>
     </table>

--- a/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-24.006-24.007.sql
+++ b/nirc_ehr/resources/schemas/dbscripts/postgresql/nirc_ehr-24.006-24.007.sql
@@ -1,0 +1,8 @@
+SELECT core.executeJavaUpgradeCode('reloadFolder');
+
+SELECT core.executeJavaUpgradeCode('etl;{NIRC_EHR}/cases;truncate');
+
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;lookup_sets;/data/lookup_sets.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;problem_list_category;/data/problem_list_category.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;problem_list_subcategory;/data/problem_list_subcategory.tsv');
+SELECT core.executeJavaUpgradeCode('importFromTsv;ehr_lookups;editable_lookups;/data/editable_lookups.tsv');

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalCase.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalCase.js
@@ -1,0 +1,72 @@
+
+EHR.model.DataModelManager.registerMetadata('ClinicalCase', {
+    allQueries: {
+        Id: {
+            inheritFromParent: true,
+            editable: false,
+            hidden: true,
+            columnConfig: {
+                editable: false
+            }
+        },
+        date: {
+            editable: true,
+            hidden: false,
+            columnConfig: {
+                editable: true
+            }
+        },
+        caseid: {
+            inheritFromParent: true,
+            editable: false,
+            hidden: true,
+            columnConfig: {
+                editable: false
+            }
+        }
+    },
+    byQuery: {
+        'study.cases': {
+            Id: {
+                inheritFromParent: false,
+                editable: true,
+                hidden: false,
+                columnConfig: {
+                    editable: true
+                }
+            },
+            category: {
+                getInitialValue: function(v, rec){
+                    return 'Clinical'
+                },
+                editable: false,
+                hidden: true,
+                columnConfig: {
+                    editable: false
+                }
+            },
+            problemCategory: {
+                editorConfig: {
+                    listeners: {
+                        select: function(field, recs){
+                            if (!recs || recs.length !== 1)
+                                return;
+
+                            var record = EHR.DataEntryUtils.getBoundRecord(field);
+                            if (record){
+                                var rec = recs[0];
+                                var meta = record.store.model.prototype.fields.get('problemSubcategory');
+                                var storeId = LABKEY.ext4.Util.getLookupStoreId(meta);
+                                var store = Ext4.StoreMgr.get(storeId);
+                                if (store){
+                                    store.filterArray = [LABKEY.Filter.create('category', rec.get('value'))];
+                                    store.load();
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+});

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
+    allQueries: {
+        performedby: {
+            defaultValue: LABKEY.Security.currentUser.displayName
+        },
+    },
+    byQuery: {
+        'study.treatment_order': {
+            category: {
+                defaultValue: 'Clinical',
+                hidden: true
+            }
+        },
+        'study.drug': {
+            category: {
+                defaultValue: 'Clinical',
+                hidden: true
+            }
+        },
+        'study.procedure': {
+            category: {
+                defaultValue: 'Clinical',
+                hidden: true
+            }
+        },
+        'study.clinremarks': {
+            category: {
+                defaultValue: 'Clinical',
+                hidden: true,
+                allowBlank: false
+            }
+        },
+        'study.blood': {
+            reason: {
+                defaultValue: 'Clinical'
+            }
+        },
+        'study.cases': {
+            qcstate: {
+                hidden: true
+            },
+            openDiagnosis: {
+                hidden: true
+            },
+            closeDiagnosis: {
+                hidden: true
+            },
+            attachmentFile: {
+                hidden: true
+            },
+            category: {
+                hidden: true
+            },
+            caseCategory: {
+                hidden: true
+            }
+        }
+    }
+});

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 LabKey Corporation
+ * Copyright (c) 2024 LabKey Corporation
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ParentChild.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ParentChild.js
@@ -7,6 +7,14 @@ EHR.model.DataModelManager.registerMetadata('ParentChild', {
             columnConfig: {
                 editable: false
             }
+        },
+        caseid: {
+            inheritFromParent: true,
+            editable: false,
+            hidden: true,
+            columnConfig: {
+                editable: false
+            }
         }
     }
 });

--- a/nirc_ehr/resources/web/nirc_ehr/panel/CaseTemplatePanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/CaseTemplatePanel.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+Ext4.define('NIRC_EHR.panel.CaseTemplatePanel', {
+    extend: 'Ext.panel.Panel',
+    alias: 'widget.nirc_ehr-casetemplatepanel',
+    plugins: ['ehr-collapsibleDataEntryPanel'],
+
+    initComponent: function(){
+        var buttons = [];
+        LDK.Assert.assertNotEmpty('No data entry panel', this.dataEntryPanel);
+        var btnCfg = EHR.DataEntryUtils.getDataEntryFormButton('APPLYFORMTEMPLATE_NO_ID');
+        if (btnCfg){
+            btnCfg = this.dataEntryPanel.configureButton(btnCfg);
+            if (btnCfg){
+                btnCfg.defaultDate = new Date();
+                btnCfg.text = 'Apply Template To Form';
+                buttons.push(btnCfg);
+            }
+        }
+
+        Ext4.apply(this, {
+            defaults: {
+
+            },
+            bodyStyle: 'padding: 5px;',
+            title: this.getTitle(),
+            items: [{
+                html: this.getHtml(),
+                maxWidth: Ext4.getBody().getWidth() * 0.8,
+                style: 'padding-top: 10px;padding-bottom: 10px;',
+                border: false
+            },{
+                layout: 'hbox',
+                border: false,
+                defaults: {
+                    style: 'margin-right: 5px;'
+                },
+                items: buttons
+            }]
+        });
+
+        this.formConfig.initCollapsed = true;
+        this.formConfig.dataDependentCollapseHeader = false;
+
+        this.callParent(arguments);
+    },
+
+    getTitle: function(){
+        return 'Case Template';
+    },
+
+    getHtml: function(){
+        return 'Start with a case template by clicking \'Apply Template To Form\' below or fill out the sections directly.';
+    }
+});

--- a/nirc_ehr/resources/web/nirc_ehr/panel/NIRCExamCasesDataEntryPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/NIRCExamCasesDataEntryPanel.js
@@ -1,0 +1,39 @@
+Ext4.define('NIRC_EHR.panel.ExamCasesDataEntryPanel', {
+    extend: 'EHR.panel.TaskDataEntryPanel',
+
+   onBeforeSubmit: function(btn){
+       if (!btn || !btn.targetQC || ['Completed', 'Review Required'].indexOf(btn.targetQC) == -1){
+           return;
+       }
+
+       var storeServer = this.storeCollection.getServerStoreByName('study.cases');
+       var storeClient = this.storeCollection.getClientStoreByName('cases');
+
+       var caseid;
+
+       // Existing case
+       if (storeClient && storeClient.data && storeClient.data.get(0) && storeClient.data.get(0).get('objectid')){
+           caseid = storeClient.data.get(0).get('objectid');
+       }
+       else { // New case
+           caseid = LABKEY.Utils.generateUUID();
+           storeServer.each(function(r){
+               r.set('objectid', caseid);
+           }, this);
+
+           storeClient.each(function(r){
+               r.set('objectid', caseid);
+           }, this);
+       }
+
+       this.storeCollection.clientStores.each(function(s){
+              if (s.getFields().get('caseid')) {
+                  s.each(function(r){
+                      r.set('caseid', caseid);
+                  }, this);
+              }
+       }, this);
+
+       return true;
+    }
+    });

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -80,7 +80,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.006; //TODO
+        return 24.007;
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -42,6 +42,7 @@ import org.labkey.nirc_ehr.dataentry.form.NIRCAliasFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCArrivalFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCAssignmentFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCBirthFormType;
+import org.labkey.nirc_ehr.dataentry.form.NIRCCasesFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCDeathNecropsyFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCDepartureFormType;
 import org.labkey.nirc_ehr.dataentry.form.NIRCExemptionsFormType;
@@ -79,7 +80,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.006;
+        return 24.006; //TODO
     }
 
     @Override
@@ -190,6 +191,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCFlagsFormType.class, this));
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCExemptionsFormType.class, this));
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCNotesFormType.class, this));
+        EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCCasesFormType.class, this));
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
@@ -48,6 +48,7 @@ public class NIRCCasesFormType extends NIRCBaseTaskFormType
         {
             s.addConfigSource("ClinicalDefaults");
             s.addConfigSource("ClinicalCase");
+            s.addConfigSource("TreatmentSchedule");
 
             if (s instanceof SimpleFormSection && !s.getName().equals("tasks"))
                 s.setTemplateMode(AbstractFormSection.TEMPLATE_MODE.NO_ID);
@@ -57,6 +58,9 @@ public class NIRCCasesFormType extends NIRCBaseTaskFormType
                 ((AbstractFormSection)s).setAllowBulkAdd(false);
             }
         }
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/TreatmentSchedule.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/field/DrugVolumeField.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/window/DrugAmountWindow.js"));
 
         addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ClinicalDefaults.js"));
         addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ClinicalCase.js"));

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
@@ -32,13 +32,13 @@ public class NIRCCasesFormType extends NIRCBaseTaskFormType
                 new NIRCAnimalDetailsFormSection(),
                 new NIRCCaseTemplateFormSection("Case Template", "Case Template", "nirc_ehr-casetemplatepanel", Arrays.asList(ClientDependency.supplierFromPath("nirc_ehr/panel/CaseTemplatePanel.js"))),
                 new NIRCCasesFormPanelSection("Clinical Case"),
-                // new NIRCClinicalObservationsFormSection(),//TODO: add
-                new NIRCWeightFormSection(true, false),
-                new NIRCTreatmentOrderFormSection(),
-                new NIRCTreatmentGivenFormSection(),
-                new NIRCHousingFormSection(true, true)
-                // new NIRCProcedureFormSection(),//TODO: add
-                // new NIRCBloodDrawsFormSection(),//TODO: add
+                // new NIRCClinicalObservationsFormSection(...),//TODO: add
+                new NIRCWeightFormSection(true, false, true, "cases"),
+                new NIRCTreatmentOrderFormSection(true, "cases"),
+                new NIRCTreatmentGivenFormSection(true, "cases"),
+                new NIRCHousingFormSection(true, true, true, "cases")
+                // new NIRCProcedureFormSection(...),//TODO: add
+                // new NIRCBloodDrawsFormSection(...),//TODO: add
         ));
 
         setTemplateMode(AbstractFormSection.TEMPLATE_MODE.NO_ID);

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
@@ -1,0 +1,78 @@
+package org.labkey.nirc_ehr.dataentry.form;
+
+import org.labkey.api.ehr.dataentry.AbstractFormSection;
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+import org.labkey.api.ehr.dataentry.FormSection;
+import org.labkey.api.ehr.dataentry.SimpleFormSection;
+import org.labkey.api.ehr.security.EHRClinicalEntryPermission;
+import org.labkey.api.module.Module;
+import org.labkey.api.query.Queryable;
+import org.labkey.api.view.template.ClientDependency;
+import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCCaseTemplateFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCCasesFormPanelSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCHousingFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCTreatmentGivenFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCTreatmentOrderFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCWeightFormSection;
+
+import java.util.Arrays;
+
+public class NIRCCasesFormType extends NIRCBaseTaskFormType
+{
+    @Queryable
+    public static final String NAME = "Clinical Cases";
+    public static final String LABEL = "Clinical Cases";
+
+    public NIRCCasesFormType(DataEntryFormContext ctx, Module owner)
+    {
+        super(ctx, owner, NAME, LABEL, "Clinical", Arrays.<FormSection>asList(
+                new NIRCTaskFormSection(),
+                new NIRCAnimalDetailsFormSection(),
+                new NIRCCaseTemplateFormSection("Case Template", "Case Template", "nirc_ehr-casetemplatepanel", Arrays.asList(ClientDependency.supplierFromPath("nirc_ehr/panel/CaseTemplatePanel.js"))),
+                new NIRCCasesFormPanelSection("Clinical Case"),
+                // new NIRCClinicalObservationsFormSection(),//TODO: add
+                new NIRCWeightFormSection(true, false),
+                new NIRCTreatmentOrderFormSection(),
+                new NIRCTreatmentGivenFormSection(),
+                new NIRCHousingFormSection(true, true)
+                // new NIRCProcedureFormSection(),//TODO: add
+                // new NIRCBloodDrawsFormSection(),//TODO: add
+        ));
+
+        setTemplateMode(AbstractFormSection.TEMPLATE_MODE.NO_ID);
+        setDisplayReviewRequired(true);
+
+        for (FormSection s : this.getFormSections())
+        {
+            s.addConfigSource("ClinicalDefaults");
+            s.addConfigSource("ClinicalCase");
+
+            if (s instanceof SimpleFormSection && !s.getName().equals("tasks"))
+                s.setTemplateMode(AbstractFormSection.TEMPLATE_MODE.NO_ID);
+
+            if (s instanceof AbstractFormSection)
+            {
+                ((AbstractFormSection)s).setAllowBulkAdd(false);
+            }
+        }
+
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ClinicalDefaults.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ClinicalCase.js"));
+        addClientDependency(ClientDependency.supplierFromPath("ehr/panel/ExamDataEntryPanel.js"));
+        setJavascriptClass("EHR.panel.ExamDataEntryPanel");
+
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/panel/NIRCExamCasesDataEntryPanel.js"));
+        setJavascriptClass("NIRC_EHR.panel.ExamCasesDataEntryPanel");
+    }
+
+    @Override
+    protected boolean canInsert()
+    {
+        if (!getCtx().getContainer().hasPermission(getCtx().getUser(), EHRClinicalEntryPermission.class))
+            return false;
+
+        return super.canInsert();
+    }
+}

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCHousingFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCHousingFormType.java
@@ -19,7 +19,7 @@ public class NIRCHousingFormType extends NIRCBaseTaskFormType
         super(ctx, owner, NAME, "Housing Transfers", "Colony Management", Arrays.asList(
                 new NIRCTaskFormSection(),
                 new NIRCAnimalDetailsFormSection(),
-                new NIRCHousingFormSection()
+                new NIRCHousingFormSection(true, false)
         ));
     }
 

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCaseTemplateFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCaseTemplateFormSection.java
@@ -1,0 +1,27 @@
+package org.labkey.nirc_ehr.dataentry.section;
+
+import org.json.JSONObject;
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+import org.labkey.api.ehr.dataentry.NonStoreFormSection;
+import org.labkey.api.view.template.ClientDependency;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class NIRCCaseTemplateFormSection extends NonStoreFormSection
+{
+    public NIRCCaseTemplateFormSection(String name, String label, String xtype, List<Supplier<ClientDependency>> dependencies)
+    {
+        super(name, label, xtype, dependencies);
+    }
+
+    @Override
+    public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
+    {
+        JSONObject json = super.toJSON(ctx, includeFormElements);
+        json.put("collapsible", true);
+        json.put("initCollapsed", true);
+        json.put("dataDependentCollapseHeader", false);
+        return json;
+    }
+}

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCasesFormPanelSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCasesFormPanelSection.java
@@ -1,0 +1,24 @@
+package org.labkey.nirc_ehr.dataentry.section;
+
+import org.json.JSONObject;
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+import org.labkey.api.ehr.dataentry.ParentFormPanelSection;
+
+public class NIRCCasesFormPanelSection extends ParentFormPanelSection
+{
+    public NIRCCasesFormPanelSection(String label)
+    {
+        super("study", "cases", label);
+        setSupportFormSort(false);
+    }
+
+    @Override
+    public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
+    {
+        JSONObject json = super.toJSON(ctx, includeFormElements);
+        json.put("collapsible", true);
+        json.put("initCollapsed", false);
+        json.put("dataDependentCollapseHeader", true);
+        return json;
+    }
+}

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCHousingFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCHousingFormSection.java
@@ -2,8 +2,8 @@ package org.labkey.nirc_ehr.dataentry.section;
 
 public class NIRCHousingFormSection extends BaseFormSection
 {
-    public NIRCHousingFormSection()
+    public NIRCHousingFormSection(boolean collapsible, boolean initCollapsed)
     {
-        super("study", "housing", "Housing Transfers", "ehr-gridpanel", true, false, false);
+        super("study", "housing", "Housing Transfers", "ehr-gridpanel", collapsible, initCollapsed, true);
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCHousingFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCHousingFormSection.java
@@ -1,9 +1,25 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
+import org.labkey.api.view.template.ClientDependency;
+
 public class NIRCHousingFormSection extends BaseFormSection
 {
     public NIRCHousingFormSection(boolean collapsible, boolean initCollapsed)
     {
         super("study", "housing", "Housing Transfers", "ehr-gridpanel", collapsible, initCollapsed, true);
+    }
+
+    public NIRCHousingFormSection(boolean collapsible, boolean initCollapsed, boolean isChild, String parentQueryName)
+    {
+        this(collapsible, initCollapsed);
+        if (isChild)
+        {
+            addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ParentChild.js"));
+            addConfigSource("ParentChild");
+
+            addClientDependency(ClientDependency.supplierFromPath("ehr/data/ChildClientStore.js"));
+            setClientStoreClass("EHR.data.ChildClientStore");
+            addExtraProperty("parentQueryName", parentQueryName);
+        }
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentGivenFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentGivenFormSection.java
@@ -1,5 +1,7 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
+import org.labkey.api.view.template.ClientDependency;
+
 public class NIRCTreatmentGivenFormSection extends BaseFormSection
 {
     public static final String LABEL = "Medications/Treatments Given";
@@ -7,5 +9,19 @@ public class NIRCTreatmentGivenFormSection extends BaseFormSection
     public NIRCTreatmentGivenFormSection()
     {
         super("study", "drug", LABEL, "ehr-gridpanel", true, true, true);
+    }
+
+    public NIRCTreatmentGivenFormSection(boolean isChild, String parentQueryName)
+    {
+        this();
+        if (isChild)
+        {
+            addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ParentChild.js"));
+            addConfigSource("ParentChild");
+
+            addClientDependency(ClientDependency.supplierFromPath("ehr/data/ChildClientStore.js"));
+            setClientStoreClass("EHR.data.ChildClientStore");
+            addExtraProperty("parentQueryName", parentQueryName);
+        }
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentOrderFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentOrderFormSection.java
@@ -1,5 +1,7 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
+import org.labkey.api.view.template.ClientDependency;
+
 public class NIRCTreatmentOrderFormSection extends BaseFormSection
 {
     public static final String LABEL = "Medications/Treatments Orders";
@@ -7,5 +9,19 @@ public class NIRCTreatmentOrderFormSection extends BaseFormSection
     public NIRCTreatmentOrderFormSection()
     {
         super("study", "treatment_order", LABEL, "ehr-gridpanel", true, true, true);
+    }
+
+    public NIRCTreatmentOrderFormSection(boolean isChild, String parentQueryName)
+    {
+        this();
+        if (isChild)
+        {
+            addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ParentChild.js"));
+            addConfigSource("ParentChild");
+
+            addClientDependency(ClientDependency.supplierFromPath("ehr/data/ChildClientStore.js"));
+            setClientStoreClass("EHR.data.ChildClientStore");
+            addExtraProperty("parentQueryName", parentQueryName);
+        }
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCWeightFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCWeightFormSection.java
@@ -1,9 +1,26 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
+import org.labkey.api.ehr.EHRService;
+import org.labkey.api.view.template.ClientDependency;
+
 public class NIRCWeightFormSection extends BaseFormSection
 {
     public NIRCWeightFormSection(boolean initCollapsed, boolean addCopyFromSection)
     {
         super("study", "weight", "Weights", "ehr-gridpanel", true, initCollapsed, addCopyFromSection);
+    }
+
+    public NIRCWeightFormSection(boolean initCollapsed, boolean addCopyFromSection, boolean isChild, String parentQueryName)
+    {
+        this(initCollapsed, addCopyFromSection);
+        if (isChild)
+        {
+            addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/ParentChild.js"));
+            addConfigSource("ParentChild");
+
+            addClientDependency(ClientDependency.supplierFromPath("ehr/data/ChildClientStore.js"));
+            setClientStoreClass("EHR.data.ChildClientStore");
+            addExtraProperty("parentQueryName", parentQueryName);
+        }
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
@@ -123,6 +123,10 @@ public class NIRC_EHRCustomizer extends AbstractTableCustomizer
         {
             EHRService.get().addIsActiveCol(ti, false, EHRService.EndingOption.activeAfterMidnightTonight, EHRService.EndingOption.allowSameDay);
         }
+        if (matches(ti, "study", "treatment_order"))
+        {
+            EHRService.get().addIsActiveCol(ti, false, EHRService.EndingOption.activeAfterMidnightTonight, EHRService.EndingOption.allowSameDay);
+        }
     }
 
     public void doSharedCustomization(AbstractTableInfo ti)


### PR DESCRIPTION
#### Rationale
Create an initial iteration for Clinical Cases data entry to include Cases as a main section and other possibly relevant data entry sections that goes along with it.

[Spec](https://docs.google.com/document/d/1G6yNOEpRuc3sbbzZlmWPcmB3VJ-wNIE7IOQihPBDgDk/edit)

Not included in this PR:
- Procedures, Blood Draws, and Clinical Observation data entry sections are getting created as part of Bulk Clinical Data Entry work, hence, not created in this PR but will get added as part of subsequent iteration(s).
- Reporting that includes navigation link to the open cases is also not included in this PR, but will get added as part of subsequent iteration(s).
- Still gathering client workflow requirements so, of course, any full workflow related updates are not part of this PR, but will be part of the follow-up work once we have some understanding of client's use-cases.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update datasets and cases ETL. 
* Add 'caseid' for relevant datasets.
* Add problem category lookups for cases. 
* Add cases, weights, treatments and housing form sections to the Cases data entry.
* Handle Parent child relationships for Ids.