### PR TITLE
Remove birth delete trigger

### DIFF
--- a/nirc_ehr/resources/queries/study/birth.js
+++ b/nirc_ehr/resources/queries/study/birth.js
@@ -19,23 +19,6 @@ function onInit(event, helper){
     helper.decodeExtraContextProperty('birthsInTransaction');
 }
 
-EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_DELETE, 'study', 'birth', function(helper, scriptErrors, row, oldRow) {
-    if (!helper.isETL() && !helper.isValidateOnly()) {
-        // cleanup on delete
-        if (row.taskid){
-
-            var deleteErrors = triggerHelper.deleteDatasetRecord('demographics', row.taskid);
-            if (deleteErrors){
-                EHR.Server.Utils.addError(scriptErrors, 'Id', deleteErrors, 'ERROR');
-            }
-            deleteErrors = triggerHelper.deleteDatasetRecord('housing', row.taskid);
-            if (deleteErrors){
-                EHR.Server.Utils.addError(scriptErrors, 'Id', deleteErrors, 'ERROR');
-            }
-        }
-    }
-});
-
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'birth', function(helper, scriptErrors, row, oldRow) {
 
     if (!oldRow && row.Id && triggerHelper.birthExists(row.Id)) {

--- a/nirc_ehr/resources/views/datasets.html
+++ b/nirc_ehr/resources/views/datasets.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
 Ext4.onReady(function () {
     var webpart = <%=webpartContext%>;

--- a/nirc_ehr/resources/views/enterData.html
+++ b/nirc_ehr/resources/views/enterData.html
@@ -1,6 +1,6 @@
 <div id="nirc_ehr-enter-data"></div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
     Ext4.onReady(function(){
         Ext4.create('EHR.panel.EnterDataPanel', {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -12,12 +12,10 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
-import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.nirc_ehr.notification.TriggerScriptNotification;
 import org.labkey.api.ldk.notification.NotificationService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DuplicateKeyException;
@@ -35,12 +33,11 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.nirc_ehr.NIRCDeathNotification;
+import org.labkey.nirc_ehr.notification.TriggerScriptNotification;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -178,29 +175,6 @@ public class NIRC_EHRTriggerHelper
 
         if (errors.hasErrors())
             throw errors;
-
-        return null;
-    }
-
-    public String deleteDatasetRecord(String dataset, String taskid) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException
-    {
-        if (dataset == null || taskid == null)
-        {
-             return "Failed deleting record. Incomplete information.";
-        }
-
-        TableInfo ti = getTableInfo("study", dataset);
-        if (ti == null)
-        {
-            return "Failed deleting record. Table not found: study." + dataset;
-        }
-
-        List<Map<String, Object>> lsids = Arrays.asList(new TableSelector(ti, Collections.singleton("lsid"), new SimpleFilter(FieldKey.fromString("taskid"), taskid), null).getMapArray());
-
-        if (ti.getUpdateService() != null && lsids.size() > 0)
-        {
-            ti.getUpdateService().deleteRows(_user, _container, lsids, null, null);
-        }
 
         return null;
     }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -17,8 +17,6 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.study.StudyService;
-import org.labkey.nirc_ehr.notification.TriggerScriptNotification;
 import org.labkey.api.ldk.notification.NotificationService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DuplicateKeyException;
@@ -32,6 +30,7 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.study.StudyService;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
@@ -48,7 +47,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 public class NIRC_EHRTriggerHelper
 {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -38,7 +38,6 @@ import org.labkey.nirc_ehr.NIRCDeathNotification;
 import org.labkey.nirc_ehr.NIRCOrchardFileGenerator;
 import org.labkey.nirc_ehr.NIRC_EHRManager;
 import org.labkey.nirc_ehr.notification.TriggerScriptNotification;
-import org.labkey.nirc_ehr.notification.TriggerScriptNotification;
 
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;


### PR DESCRIPTION
#### Rationale
Remove partial cleanup. As it turns out doing this partial cleanup is not a good idea and is unclear at best what is getting deleted. At worst it can result in loss of data.

#### Changes
* Remove birth delete handler
* Remove unused function
