### PR TITLE
Assign task to a Vets group upon 'Submit Death' in Death/Necropsy data entry form

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
@@ -21,12 +21,12 @@ EHR.DataEntryUtils.registerDataEntryFormButton('DEATHSUBMIT', {
                     }
                 });
 
-                // get and set 'NIRC Veterinarians' as the assignedTo value
+                // get and set 'Veterinarians' as the assignedTo value
                 var assignedToCombo = panel.down('ehr-usersandgroupscombo');
                 if (assignedToCombo) {
                     var assignedToStore = assignedToCombo.getStore();
                     if (assignedToStore.count() > 0) {
-                        var assignedToRec = assignedToStore.findRecord('DisplayName', 'NIRC Veterinarians');
+                        var assignedToRec = assignedToStore.findRecord('DisplayName', 'Veterinarians');
                         if (assignedToRec) {
                             var taskStore = panel.storeCollection.getServerStoreForQuery('ehr', 'tasks');
                             taskStore.getAt(0).set('assignedto', assignedToRec.get('UserId'));

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
@@ -20,6 +20,21 @@ EHR.DataEntryUtils.registerDataEntryFormButton('DEATHSUBMIT', {
                         store.removeAll();
                     }
                 });
+
+                // get and set 'NIRC Veterinarians' as the assignedTo value
+                var assignedToCombo = panel.down('ehr-usersandgroupscombo');
+                if (assignedToCombo) {
+                    var assignedToStore = assignedToCombo.getStore();
+                    if (assignedToStore.count() > 0) {
+                        var assignedToRec = assignedToStore.findRecord('DisplayName', 'NIRC Veterinarians');
+                        if (assignedToRec) {
+                            var taskStore = panel.storeCollection.getServerStoreForQuery('ehr', 'tasks');
+                            taskStore.getAt(0).set('assignedto', assignedToRec.get('UserId'));
+                            panel.storeCollection.transformServerToClient();
+                        }
+                    }
+                }
+
                 panel.onSubmit(submitDeathBtn);
             }
         }, this);


### PR DESCRIPTION
#### Rationale
Assign task to a Vets group upon 'Submit Death' in Death/Necropsy data entry form

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Upon 'Submit Death', assign task to a Vet group, which should be named 'Veterinarians'. Admins should add vet users to 'Veterinarians' group.