### PR TITLE
Display 'Necropsy Pending' status on Animal Details, handle 'Save Draft' for form panels.

### DIFF
--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -80,7 +80,6 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
         //only allow death record to be created if animal is in demographics table
         if (idMap[row.Id]) {
 
-            console.log("row.QCStateLabel.toUpperCase() = " + row.QCStateLabel.toUpperCase());
             var calc_status = undefined;
             if (row.QCStateLabel.toUpperCase() === 'REQUEST: PENDING' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')
                 calc_status = 'Necropsy Pending';

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -89,6 +89,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
             // If a user tries to submit a new Death record (identified by QCState = 'IN PROGRESS') for an animal that
             // already has a pending request/review status in study.deaths, then below error message will be displayed.
             else if (row.QCStateLabel.toUpperCase() === 'IN PROGRESS' &&
+                    deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel &&
                     (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
                             deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')) {
                 EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death record is pending review for this animal', 'ERROR');

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -102,10 +102,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
                     deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'IN PROGRESS') {
                 EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death/Necropsy data entry is in progress for this animal', 'ERROR');
             }
-            else if (!helper.isValidateOnly() && row.Id && row.date &&
-                    (row.QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
-                    row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED' ||
-                    row.QCStateLabel.toUpperCase() === 'COMPLETED')) {
+            else if (!helper.isValidateOnly() && row.Id && row.date && row.QCStateLabel.toUpperCase() === 'COMPLETED') {
 
                 if (validIds.indexOf(row.id) !== -1) {
 
@@ -131,6 +128,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'deaths', function(helper, scriptErrors, row, oldRow) {
     helper.registerDeath(row.Id, row.date);
+    triggerHelper.reportDataChange("study", "deaths", [row.Id]);
 });
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.COMPLETE, 'study', 'Deaths', function(event, errors, helper){

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -9,12 +9,6 @@ function onInit(event, helper){
 
     helper.decodeExtraContextProperty('deathsInTransaction');
 
-    helper.setScriptOptions({
-        allowAnyId: true,
-        requiresStatusRecalc: true,
-        allowDatesInDistantPast: true
-    });
-
     // Cache valid Ids for check on each row
     LABKEY.Query.selectRows({
         requiredVersion: 9.1,
@@ -80,13 +74,6 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
         //only allow death record to be created if animal is in demographics table
         if (idMap[row.Id]) {
 
-            var calc_status = undefined;
-            if (row.QCStateLabel.toUpperCase() === 'REQUEST: PENDING' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')
-                calc_status = 'Necropsy Pending';
-            else if (row.QCStateLabel.toUpperCase() === 'COMPLETED')
-                calc_status = 'Dead';
-
-
             // check if death record already exists for this animal
             if (idMap[row.Id].calculated_status.toUpperCase() === 'DEAD' && row.QCStateLabel.toUpperCase() === 'COMPLETED') {
                 EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death record already exists for this animal.', 'ERROR');
@@ -107,6 +94,14 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
                             deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')) {
                 EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death record is pending review for this animal', 'ERROR');
             }
+            // if 'Save Draft' record already exists, it doesn't allow to 'Save Draft' or 'Submit Death'
+            // on the same animal again - throws an error "duplicate key value violates unique constraint"
+            // So, added this check to allow 'Save Draft' record to be saved only once.
+            else if (oldRow === undefined && row.QCStateLabel.toUpperCase() === 'IN PROGRESS' &&
+                    deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel &&
+                    deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'IN PROGRESS') {
+                EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death/Necropsy data entry is in progress for this animal', 'ERROR');
+            }
             else if (!helper.isValidateOnly() && row.Id && row.date &&
                     (row.QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
                     row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED' ||
@@ -114,12 +109,11 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
                 if (validIds.indexOf(row.id) !== -1) {
 
-                    console.log("calc_status = " + calc_status);
                     // update demographics
                     demographicsUpdates.push({
                         Id: row.Id,
-                        death: calc_status === 'Dead' ? row.date : null,
-                        calculated_status: calc_status,
+                        death: row.date,
+                        calculated_status: 'Dead',
                         QCState: helper.getJavaHelper().getQCStateForLabel(row.QCStateLabel).getRowId()
                     });
 

--- a/nirc_ehr/resources/queries/study/necropsy.js
+++ b/nirc_ehr/resources/queries/study/necropsy.js
@@ -32,7 +32,8 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
     if (!helper.isETL()) {
 
         if (deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel &&
-                (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
+                (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'IN PROGRESS' ||
+                deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
                 deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')) {
 
             if (!row.examReason)

--- a/nirc_ehr/resources/queries/study/necropsy.js
+++ b/nirc_ehr/resources/queries/study/necropsy.js
@@ -31,8 +31,9 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
     if (!helper.isETL()) {
 
-        if (deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
-                deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED') {
+        if (deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel &&
+                (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
+                deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')) {
 
             if (!row.examReason)
                 EHR.Server.Utils.addError(scriptErrors, 'examReason', "'Reason for Examination' is required", 'ERROR');

--- a/nirc_ehr/resources/queries/study/necropsy.js
+++ b/nirc_ehr/resources/queries/study/necropsy.js
@@ -32,8 +32,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
     if (!helper.isETL()) {
 
         if (deathIdMap[row.Id] && deathIdMap[row.Id].QCStateLabel &&
-                (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'IN PROGRESS' ||
-                deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
+                (deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REQUEST: PENDING' ||
                 deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'REVIEW REQUIRED')) {
 
             if (!row.examReason)

--- a/nirc_ehr/resources/queries/study/necropsy.js
+++ b/nirc_ehr/resources/queries/study/necropsy.js
@@ -60,3 +60,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
         }
     }
 }
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'necropsy', function(helper, scriptErrors, row, oldRow) {
+    triggerHelper.reportDataChange("study", "necropsy", [row.Id]);
+});

--- a/nirc_ehr/resources/queries/study/necropsyStatus.sql
+++ b/nirc_ehr/resources/queries/study/necropsyStatus.sql
@@ -1,0 +1,5 @@
+SELECT
+    demo.Id,
+    CASE WHEN d.QCState.Label = 'Request: Pending' OR d.QCState.Label = 'Review Required' THEN 'Necropsy Pending' ELSE demo.calculated_status END AS calculated_status
+    FROM study.demographics demo
+LEFT JOIN study.deaths d ON d.Id = demo.Id

--- a/nirc_ehr/resources/queries/study/necropsyStatus.sql
+++ b/nirc_ehr/resources/queries/study/necropsyStatus.sql
@@ -1,5 +1,5 @@
 SELECT
     demo.Id,
-    CASE WHEN d.QCState.Label = 'Request: Pending' OR d.QCState.Label = 'Review Required' THEN 'Necropsy Pending' ELSE demo.calculated_status END AS calculated_status
+    CASE WHEN d.QCState.Label = 'Request: Pending' OR d.QCState.Label = 'Review Required' THEN 'Necropsy Pending' ELSE demo.calculated_status END AS necropsy_status
     FROM study.demographics demo
 LEFT JOIN study.deaths d ON d.Id = demo.Id

--- a/nirc_ehr/resources/scripts/nirc_triggers.js
+++ b/nirc_ehr/resources/scripts/nirc_triggers.js
@@ -100,9 +100,11 @@ exports.init = function (EHR) {
             datasetsToClose: ['assignment', 'protocolAssignment' , 'housing', 'treatment_order', 'observation_order', 'cases', 'pairings', 'exemptions', 'flags'],
             allowShippedIds: false,
             allowDeadIds: false,
-            requiresStatusRecalc: false,
+            requiresStatusRecalc: true,
             allowRequestsInPast: true,
-            removeTimeFromDate: false
+            removeTimeFromDate: false,
+            allowDatesInDistantPast: true,
+            allowAnyId: true
         });
     });
 

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
@@ -1,22 +1,6 @@
 /**
- * A button specific to the Death-Necropsy form
+ * Buttons specific to the Death-Necropsy form
  */
-
-EHR.DataEntryUtils.registerDataEntryFormButton('DEATHNECROPSYSAVEDRAFT', {
-    text: 'Save Draft',
-    name: 'deathNecropsySaveDraft',
-    errorThreshold: 'ERROR',
-    successURL: LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
-    itemId: 'deathNecropsySaveDraftBtn',
-    disabled: false,
-    requiredQC: 'In Progress',
-    targetQC: 'In Progress',
-    handler: function(btn){
-        var panel = btn.up('ehr-dataentrypanel');
-        panel.onSubmit(btn, false, true);
-    },
-    disableOn: 'ERROR'
-});
 
 EHR.DataEntryUtils.registerDataEntryFormButton('DEATHSUBMIT', {
     text: 'Submit Death',

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
@@ -2,6 +2,22 @@
  * A button specific to the Death-Necropsy form
  */
 
+EHR.DataEntryUtils.registerDataEntryFormButton('DEATHNECROPSYSAVEDRAFT', {
+    text: 'Save Draft',
+    name: 'deathNecropsySaveDraft',
+    errorThreshold: 'ERROR',
+    successURL: LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    itemId: 'deathNecropsySaveDraftBtn',
+    disabled: false,
+    requiredQC: 'In Progress',
+    targetQC: 'In Progress',
+    handler: function(btn){
+        var panel = btn.up('ehr-dataentrypanel');
+        panel.onSubmit(btn, false, true);
+    },
+    disableOn: 'ERROR'
+});
+
 EHR.DataEntryUtils.registerDataEntryFormButton('DEATHSUBMIT', {
     text: 'Submit Death',
     name: 'submitDeath',

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/saveDraftButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/saveDraftButton.js
@@ -1,0 +1,15 @@
+EHR.DataEntryUtils.registerDataEntryFormButton('NIRCSAVEDRAFTBUTTON', {
+    text: 'Save Draft',
+    name: 'nircSaveDraft',
+    errorThreshold: 'ERROR',
+    successURL: LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    itemId: 'nircSaveDraftBtn',
+    disabled: false,
+    requiredQC: 'In Progress',
+    targetQC: 'In Progress',
+    handler: function(btn){
+        var panel = btn.up('ehr-dataentrypanel');
+        panel.onSubmit(btn, false, true);
+    },
+    disableOn: 'ERROR'
+});

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
@@ -80,6 +80,16 @@ EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
             }
         },
         'study.cases': {
+            QCState: {
+                allowBlank: false,
+                getInitialValue: function(v){
+                    var qc;
+                    if (!v && EHR.Security.getQCStateByLabel('In Progress'))
+                        qc = EHR.Security.getQCStateByLabel('In Progress').RowId;
+                    return v || qc;
+                },
+                shownInGrid: false
+            },
             openRemark: {
                 height: 120
             },
@@ -112,6 +122,16 @@ EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
             }
         },
         'study.clinremarks': {
+            QCState: {
+                allowBlank: false,
+                getInitialValue: function(v){
+                    var qc;
+                    if (!v && EHR.Security.getQCStateByLabel('In Progress'))
+                        qc = EHR.Security.getQCStateByLabel('In Progress').RowId;
+                    return v || qc;
+                },
+                shownInGrid: false
+            },
             hx: {
                 formEditorConfig: {
                     xtype: 'ehr-hxtextarea'

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
@@ -80,16 +80,6 @@ EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
             }
         },
         'study.cases': {
-            QCState: {
-                allowBlank: false,
-                getInitialValue: function(v){
-                    var qc;
-                    if (!v && EHR.Security.getQCStateByLabel('In Progress'))
-                        qc = EHR.Security.getQCStateByLabel('In Progress').RowId;
-                    return v || qc;
-                },
-                shownInGrid: false
-            },
             openRemark: {
                 height: 120
             },
@@ -122,16 +112,6 @@ EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
             }
         },
         'study.clinremarks': {
-            QCState: {
-                allowBlank: false,
-                getInitialValue: function(v){
-                    var qc;
-                    if (!v && EHR.Security.getQCStateByLabel('In Progress'))
-                        qc = EHR.Security.getQCStateByLabel('In Progress').RowId;
-                    return v || qc;
-                },
-                shownInGrid: false
-            },
             hx: {
                 formEditorConfig: {
                     xtype: 'ehr-hxtextarea'

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
@@ -65,6 +65,14 @@ EHR.model.DataModelManager.registerMetadata('Default', {
                 width: 150
             },
         },
+        QCState: {
+            getInitialValue: function (v) {
+                var qc;
+                if (!v && EHR.Security.getQCStateByLabel('In Progress'))
+                    qc = EHR.Security.getQCStateByLabel('In Progress').RowId;
+                return v || qc || 'In Progress';
+            }
+        }
     },
     byQuery: {
         'study.housing': {

--- a/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
@@ -141,9 +141,16 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
             toSet['animalId'] = LABKEY.Utils.encodeHtml(id);
         }
 
-        var status = row.getCalculatedStatus() || 'Unknown';
-        toSet['calculated_status'] = '<span ' + (status.toLowerCase() !== 'alive' ? 'style="background-color:yellow"' : '') + '>'
-                + LABKEY.Utils.encodeHtml(status) + '</span>';
+        var status = row.getCalculatedStatus();
+        var statusVal = 'Unknown';
+        if (typeof status == 'string'){
+            statusVal  = status;
+        }
+        else {
+            statusVal = status[0] && (Object.keys(status[0]).length > 0) ? status[0].calculated_status : statusVal;
+        }
+        toSet['calculated_status'] = '<span ' + (statusVal !== 'Alive' ? 'style="background-color:yellow"' : '') + '>'
+                + LABKEY.Utils.encodeHtml(statusVal) + '</span>';
 
         toSet['species'] = LABKEY.Utils.encodeHtml(row.getSpeciesCommonName());
         toSet['geographic_origin'] = LABKEY.Utils.encodeHtml(row.getGeographicOrigin());

--- a/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
@@ -31,6 +31,14 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
         });
     },
 
+    onLoad: function(ids, resultMap){
+        if (ids && ids.length && ids[0] != this.subjectId){
+            return;
+        }
+
+        this.callParent(arguments);
+    },
+
     getBaseItems: function(){
         return [{
             xtype: 'container',
@@ -87,7 +95,7 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
                     items: [{
                         xtype: 'displayfield',
                         fieldLabel: 'Status',
-                        name: 'necropsy_status'
+                        name: 'calculated_status'
                     },{
                         xtype: 'displayfield',
                         fieldLabel: 'Sex',

--- a/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
+++ b/nirc_ehr/resources/web/nirc_ehr/panel/SnapshotPanel.js
@@ -87,7 +87,7 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
                     items: [{
                         xtype: 'displayfield',
                         fieldLabel: 'Status',
-                        name: 'calculated_status'
+                        name: 'necropsy_status'
                     },{
                         xtype: 'displayfield',
                         fieldLabel: 'Sex',
@@ -141,13 +141,15 @@ Ext4.define('NIRC_EHR.panel.SnapshotPanel', {
             toSet['animalId'] = LABKEY.Utils.encodeHtml(id);
         }
 
-        var status = row.getCalculatedStatus();
+        var data = row.getData();
+        var status = data ? data.necropsy_status : undefined;
         var statusVal = 'Unknown';
-        if (typeof status == 'string'){
-            statusVal  = status;
-        }
-        else {
-            statusVal = status[0] && (Object.keys(status[0]).length > 0) ? status[0].calculated_status : statusVal;
+        if (status) {
+            if (typeof status == 'string') {
+                statusVal = status;
+            } else {
+                statusVal = status[0] && (Object.keys(status[0]).length > 0) ? status[0].necropsy_status : statusVal;
+            }
         }
         toSet['calculated_status'] = '<span ' + (statusVal !== 'Alive' ? 'style="background-color:yellow"' : '') + '>'
                 + LABKEY.Utils.encodeHtml(statusVal) + '</span>';

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -50,6 +50,7 @@ import org.labkey.nirc_ehr.demographics.ActiveCasesDemographicsProvider;
 import org.labkey.nirc_ehr.demographics.ActiveFlagsDemographicsProvider;
 import org.labkey.nirc_ehr.demographics.CagematesDemographicsProvider;
 import org.labkey.nirc_ehr.demographics.HousingDemographicsProvider;
+import org.labkey.nirc_ehr.demographics.NecropsyStatusDemographicsProvider;
 import org.labkey.nirc_ehr.demographics.ProtocolAssignmentDemographicsProvider;
 import org.labkey.nirc_ehr.history.*;
 import org.labkey.nirc_ehr.query.NIRC_EHRUserSchema;
@@ -131,6 +132,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
         ehrService.registerDemographicsProvider(new ActiveCasesDemographicsProvider(this));
         ehrService.registerDemographicsProvider(new ActiveTreatmentsDemographicsProvider(this));
         ehrService.registerDemographicsProvider(new SourceDemographicsProvider(this));
+        ehrService.registerDemographicsProvider(new NecropsyStatusDemographicsProvider(this));
 
         EHRService.get().registerHistoryDataSource(new ArrivalDataSource(this));
         EHRService.get().registerHistoryDataSource(new BiopsyDataSource(this));

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBaseTaskFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBaseTaskFormType.java
@@ -17,13 +17,14 @@ public class NIRCBaseTaskFormType extends TaskForm
 
         addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/plugin/RowEditor.js"));
         addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/NIRCDefault.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/buttons/saveDraftButton.js"));
     }
 
     @Override
     protected List<String> getButtonConfigs()
     {
         List<String> defaultButtons = new ArrayList<>();
-        defaultButtons.add("SAVEDRAFT");
+        defaultButtons.add("NIRCSAVEDRAFTBUTTON");
         defaultButtons.add("REVIEW");
         defaultButtons.add("SUBMIT");
 

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
@@ -49,7 +49,6 @@ public class NIRCDeathNecropsyFormType extends NIRCBaseTaskFormType
         boolean isVetTech = getCtx().getContainer().hasPermission(getCtx().getUser(), NIRCEHRVetTechPermission.class);
         boolean isVet = getCtx().getContainer().hasPermission(getCtx().getUser(), EHRVeterinarianPermission.class);
 
-        defaultButtons.add("DEATHNECROPSYSAVEDRAFT");
         defaultButtons.add("DEATHSUBMIT");
 
         if (isVetTech)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
@@ -49,7 +49,7 @@ public class NIRCDeathNecropsyFormType extends NIRCBaseTaskFormType
         boolean isVetTech = getCtx().getContainer().hasPermission(getCtx().getUser(), NIRCEHRVetTechPermission.class);
         boolean isVet = getCtx().getContainer().hasPermission(getCtx().getUser(), EHRVeterinarianPermission.class);
 
-        defaultButtons.add("SAVEDRAFT");
+        defaultButtons.add("DEATHNECROPSYSAVEDRAFT");
         defaultButtons.add("DEATHSUBMIT");
 
         if (isVetTech)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
@@ -49,6 +49,7 @@ public class NIRCDeathNecropsyFormType extends NIRCBaseTaskFormType
         boolean isVetTech = getCtx().getContainer().hasPermission(getCtx().getUser(), NIRCEHRVetTechPermission.class);
         boolean isVet = getCtx().getContainer().hasPermission(getCtx().getUser(), EHRVeterinarianPermission.class);
 
+        defaultButtons.add("NIRCSAVEDRAFTBUTTON");
         defaultButtons.add("DEATHSUBMIT");
 
         if (isVetTech)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
@@ -1,0 +1,35 @@
+package org.labkey.nirc_ehr.demographics;
+
+import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
+import org.labkey.api.module.Module;
+import org.labkey.api.query.FieldKey;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class NecropsyStatusDemographicsProvider extends AbstractListDemographicsProvider
+{
+
+    public NecropsyStatusDemographicsProvider(Module module)
+    {
+        super(module, "study", "necropsyStatus", "calculated_status");
+        _supportsQCState = false;
+    }
+
+    @Override
+    public boolean isAsync()
+    {
+        return true;
+    }
+
+    @Override
+    protected Collection<FieldKey> getFieldKeys()
+    {
+        Set<FieldKey> keys = new HashSet<FieldKey>();
+        keys.add(FieldKey.fromString("Id"));
+        keys.add(FieldKey.fromString("calculated_status"));
+
+        return keys;
+    }
+}

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
@@ -1,11 +1,15 @@
 package org.labkey.nirc_ehr.demographics;
 
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.FieldKey;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class NecropsyStatusDemographicsProvider extends AbstractListDemographicsProvider
@@ -18,9 +22,10 @@ public class NecropsyStatusDemographicsProvider extends AbstractListDemographics
     }
 
     @Override
-    public boolean isAsync()
+    public boolean requiresRecalc(String schema, String query)
     {
-        return true;
+        return ("study".equalsIgnoreCase(schema) && "deaths".equalsIgnoreCase(query)) ||
+                ("study".equalsIgnoreCase(schema) && "demographics".equalsIgnoreCase(query));
     }
 
     @Override
@@ -31,5 +36,20 @@ public class NecropsyStatusDemographicsProvider extends AbstractListDemographics
         keys.add(FieldKey.fromString("necropsy_status"));
 
         return keys;
+    }
+
+    protected SimpleFilter getFilter(Collection<String> ids)
+    {
+        List<String> qcStates = new ArrayList<>();
+        qcStates.add("Completed");
+        qcStates.add("Review Required");
+        qcStates.add("Request: Pending");
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), ids, CompareType.IN);
+        if (_supportsQCState)
+        {
+            filter.addCondition(FieldKey.fromString("QCState/Label"), qcStates, CompareType.IN);
+        }
+
+        return filter;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
@@ -13,7 +13,7 @@ public class NecropsyStatusDemographicsProvider extends AbstractListDemographics
 
     public NecropsyStatusDemographicsProvider(Module module)
     {
-        super(module, "study", "necropsyStatus", "calculated_status");
+        super(module, "study", "necropsyStatus", "necropsy_status");
         _supportsQCState = false;
     }
 
@@ -28,7 +28,7 @@ public class NecropsyStatusDemographicsProvider extends AbstractListDemographics
     {
         Set<FieldKey> keys = new HashSet<FieldKey>();
         keys.add(FieldKey.fromString("Id"));
-        keys.add(FieldKey.fromString("calculated_status"));
+        keys.add(FieldKey.fromString("necropsy_status"));
 
         return keys;
     }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -18,6 +18,7 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.ehr.EHRDemographicsService;
 import org.labkey.api.ehr.security.EHRVeterinarianPermission;
 import org.labkey.api.ldk.notification.NotificationService;
 import org.labkey.api.query.BatchValidationException;
@@ -36,6 +37,7 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.Pair;
 import org.labkey.nirc_ehr.NIRCDeathNotification;
 import org.labkey.nirc_ehr.NIRCOrchardFileGenerator;
 import org.labkey.nirc_ehr.NIRC_EHRManager;
@@ -738,5 +740,10 @@ public class NIRC_EHRTriggerHelper
 
         TableSelector ts = new TableSelector(ti, Collections.singleton("Id"), filter, null);
         return ts.exists();
+    }
+
+    public void reportDataChange(String schema, String query, final List<String> ids)
+    {
+        EHRDemographicsService.get().reportDataChange(_container, schema, query, ids);
     }
 }


### PR DESCRIPTION
#### Rationale
As the first round of client testing, we found that 'Save Draft' was setting the QC State as 'Completed' rather than 'In Progress'.
Additionally, client would like to see 'Necropsy Pending' status on Animal Details once Death is submitted or Necropsy is under Review.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Implement customized 'SAVE DRAFT' button with targetQCState property set to 'In Progress'.
* Add form config for QCState to have an initial value; otherwise, it defaults to null (esp. for the data entry forms containing form panels, but not for grid panels), causing the QCState Label to be set to 'Completed' in security.js during 'SAVE DRAFT'.
* Handle client side error 'Cannot read property "QCStateLabel" from undefined'.
* Display 'Necropsy Pending' on Animal Details.
