### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/nirc_ehr/module.properties
+++ b/nirc_ehr/module.properties
@@ -1,2 +1,1 @@
 ModuleClass: org.labkey.nirc_ehr.NIRC_EHRModule
-SupportedDatabases: pgsql


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067