### PR TITLE
Add ManageVersion property to all module.properties files

### DIFF
--- a/nirc_ehr/module.properties
+++ b/nirc_ehr/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.nirc_ehr.NIRC_EHRModule
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We want every LabKey-managed module to specify the `ManageVersion` property. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369
