### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/nirc_ehr/resources/views/enterData.view.xml
+++ b/nirc_ehr/resources/views/enterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Enter Data" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="ehr/panel/EnterDataPanel.js"/>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.