### PR TITLE
Align frequency from formulary with frequency data

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/data/DrugAdministrationRunsChildClientStore.js
+++ b/nirc_ehr/resources/web/nirc_ehr/data/DrugAdministrationRunsChildClientStore.js
@@ -1,6 +1,6 @@
 
 Ext4.define('NIRC_EHR.data.DrugAdministrationRunsChildClientStore', {
-    extend: 'EHR.data.DrugAdministrationRunsClientStore',
+    extend: 'NIRC_EHR.data.DrugAdministrationRunsClientStore',
 
     insert: function(index, records) {
         var ret = this.callParent(arguments);

--- a/nirc_ehr/resources/web/nirc_ehr/data/DrugAdministrationRunsClientStore.js
+++ b/nirc_ehr/resources/web/nirc_ehr/data/DrugAdministrationRunsClientStore.js
@@ -1,0 +1,54 @@
+Ext4.define('NIRC_EHR.data.DrugAdministrationRunsClientStore', {
+    extend: 'EHR.data.DrugAdministrationRunsClientStore',
+
+    // This override adds a special case for frequency to align formulary frequency.rowid with data frequency.meaning
+    onRecordUpdate: function (record, modifiedFieldNames) {
+        if (record.get('code')) {
+            modifiedFieldNames = modifiedFieldNames || [];
+
+            if (modifiedFieldNames.indexOf('code') == -1) {
+                return;
+            }
+
+            if (!this.formularyStore) {
+                LDK.Utils.logToServer({
+                    message: 'Unable to find formulary store in DrugAdministrationRunsClientStore'
+                });
+                console.error('Unable to find formulary store in DrugAdministrationRunsClientStore');
+
+                return;
+            }
+
+            var values = this.formularyStore.getFormularyValues(record.get('code'));
+            if (!Ext4.Object.isEmpty(values)) {
+                var params = {};
+
+                for (var fieldName in this.fieldMap) {
+                    if (!this.getFields().get(fieldName)) {
+                        continue;
+                    }
+
+                    if (modifiedFieldNames.indexOf(this.fieldMap[fieldName]) != -1) {
+                        continue;
+                    }
+
+                    let def = values[fieldName];
+
+                    // Special case for frequency to align the formulary frequency rowid with data stored as the meaning
+                    if (fieldName.toLowerCase() === 'frequency')
+                        def = values['frequency/meaning']
+
+                    if (Ext4.isDefined(def)) {
+                        params[this.fieldMap[fieldName]] = def;
+                    }
+                }
+
+                if (!LABKEY.Utils.isEmptyObj(params)) {
+                    record.beginEdit();
+                    record.set(params);
+                    record.endEdit(true);
+                }
+            }
+        }
+    }
+});

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentGivenFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentGivenFormSection.java
@@ -11,8 +11,9 @@ public class NIRCTreatmentGivenFormSection extends BaseFormSection
     public NIRCTreatmentGivenFormSection()
     {
         super("study", "drug", LABEL, "ehr-gridpanel", true, true, true);
-        setClientStoreClass("EHR.data.DrugAdministrationRunsClientStore");
+        setClientStoreClass("NIRC_EHR.data.DrugAdministrationRunsClientStore");
         addClientDependency(ClientDependency.supplierFromPath("ehr/data/DrugAdministrationRunsClientStore.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/data/DrugAdministrationRunsClientStore.js"));
     }
 
     public NIRCTreatmentGivenFormSection(boolean isChild, String parentQueryName)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentOrderFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCTreatmentOrderFormSection.java
@@ -11,8 +11,9 @@ public class NIRCTreatmentOrderFormSection extends BaseFormSection
     public NIRCTreatmentOrderFormSection()
     {
         super("study", "treatment_order", LABEL, "ehr-gridpanel", true, true, true);
-        setClientStoreClass("EHR.data.DrugAdministrationRunsClientStore");
+        setClientStoreClass("NIRC_EHR.data.DrugAdministrationRunsClientStore");
         addClientDependency(ClientDependency.supplierFromPath("ehr/data/DrugAdministrationRunsClientStore.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/data/DrugAdministrationRunsClientStore.js"));
     }
 
     public NIRCTreatmentOrderFormSection(boolean isChild, String parentQueryName)


### PR DESCRIPTION
#### Rationale
Conversion of using frequency meaning in data instead of frequency rowid reduces the risk of data loss, however the core EHR formulary (drug_defaults) table still uses rowid. This PR aligns the frequency from formulary with frequency from data.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/897

#### Changes
* Create DrugAdministrationRunsClientStore to add frequency handling
* Add store to form sections
