### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/deathNecropsyButtons.js
@@ -48,7 +48,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('DEATH_NECROPSY_VET_REVIEW', {
     requiredQC: 'Review Required',
     targetQC: 'Review Required',
     errorThreshold: 'WARN',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'reviewBtn',
     disableOn: 'ERROR',

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/treatmentSubmit.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/treatmentSubmit.js
@@ -5,7 +5,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('NIRC_TREATMENT_SUBMIT', {
     requiredQC: 'Completed',
     targetQC: 'Completed',
     errorThreshold: 'INFO',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'submitBtn',
     handler: function(btn){


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters