### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRCOrchardFileGenerator.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRCOrchardFileGenerator.java
@@ -1,6 +1,5 @@
 package org.labkey.nirc_ehr;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -8,7 +7,6 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleProperty;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRManager.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRManager.java
@@ -12,7 +12,7 @@ public class NIRC_EHRManager
     public static final String SIB_OBS_TITLE = "SIB Observations";
     public static final List<String> SIB_OBS = List.of("Environmental Change", "Self Biting Observed", "Other Stereotopy", "New Injury Observed", "Special Enrichment", "Wound Status", "Wound Severity");
 
-    private static NIRCOrchardFileGenerator _orchardFileGenerator = new NIRCOrchardFileGenerator();
+    private static final NIRCOrchardFileGenerator _orchardFileGenerator = new NIRCOrchardFileGenerator();
     public static NIRCOrchardFileGenerator getOrchardFileGenerator()
     {
         return _orchardFileGenerator;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCArrivalFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCArrivalFormType.java
@@ -8,8 +8,6 @@ import org.labkey.api.view.template.ClientDependency;
 import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCArrivalFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCArrivalInstructionsFormSection;
-import org.labkey.nirc_ehr.dataentry.section.NIRCProjectAssignmentFormSection;
-import org.labkey.nirc_ehr.dataentry.section.NIRCProtocolAssignmentFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCWeightFormSection;
 

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBirthFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBirthFormType.java
@@ -41,7 +41,7 @@ public class NIRCBirthFormType extends BirthFormType
     @Override
     protected List<String> getButtonConfigs()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         defaultButtons.add("SAVEDRAFT");
         defaultButtons.add("BIRTHARRIVALREVIEW");
         defaultButtons.add("BIRTHARRIVALFINAL");

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBulkBehaviorFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBulkBehaviorFormType.java
@@ -50,7 +50,7 @@ public class NIRCBulkBehaviorFormType extends NIRCBaseTaskFormType
             s.addConfigSource("BehaviorDefaults");
             s.addConfigSource("TreatmentSchedule");
             s.addConfigSource("MedicationEndDate");
-        };
+        }
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBulkClinicalFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBulkClinicalFormType.java
@@ -62,7 +62,7 @@ public class NIRCBulkClinicalFormType extends NIRCBaseTaskFormType
             s.addConfigSource("BulkClinical");
             s.addConfigSource("TreatmentSchedule");
             s.addConfigSource("MedicationEndDate");
-        };
+        }
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
@@ -45,7 +45,7 @@ public class NIRCDeathNecropsyFormType extends NIRCBaseTaskFormType
     @Override
     protected List<String> getButtonConfigs()
     {
-        List<String> defaultButtons = new ArrayList<String>();
+        List<String> defaultButtons = new ArrayList<>();
         boolean isVetTech = getCtx().getContainer().hasPermission(getCtx().getUser(), NIRCEHRVetTechPermission.class);
         boolean isVet = getCtx().getContainer().hasPermission(getCtx().getUser(), EHRVeterinarianPermission.class);
 

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDepartureFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDepartureFormType.java
@@ -1,9 +1,7 @@
 package org.labkey.nirc_ehr.dataentry.form;
 
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
-import org.labkey.api.ehr.dataentry.TaskForm;
 import org.labkey.api.module.Module;
-import org.labkey.api.view.template.ClientDependency;
 import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCDepartureFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCHousingFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCHousingFormType.java
@@ -3,7 +3,6 @@ package org.labkey.nirc_ehr.dataentry.form;
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.ehr.security.EHRHousingTransferPermission;
 import org.labkey.api.module.Module;
-import org.labkey.api.view.template.ClientDependency;
 import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCHousingFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCWeightFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCWeightFormType.java
@@ -2,7 +2,6 @@ package org.labkey.nirc_ehr.dataentry.form;
 
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.module.Module;
-import org.labkey.api.view.template.ClientDependency;
 import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;
 import org.labkey.nirc_ehr.dataentry.section.NIRCWeightFormSection;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCArrivalFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCArrivalFormSection.java
@@ -3,7 +3,6 @@ package org.labkey.nirc_ehr.dataentry.section;
 import org.json.JSONObject;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
-import org.labkey.api.ehr.dataentry.forms.NewAnimalFormSection;
 import org.labkey.api.query.FieldKey;
 
 import java.util.List;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCBloodDrawFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCBloodDrawFormSection.java
@@ -10,9 +10,9 @@ import java.util.List;
 
 public class NIRCBloodDrawFormSection extends BloodDrawFormSection
 {
-    private boolean _collapsible = false;
-    private boolean _initCollapsed = false;
-    private boolean _addCopyFromSection = false;
+    private boolean _collapsible;
+    private boolean _initCollapsed;
+    private boolean _addCopyFromSection;
 
     public NIRCBloodDrawFormSection(boolean collapsible, boolean initCollapsed, boolean addCopyFromSection)
     {
@@ -41,6 +41,7 @@ public class NIRCBloodDrawFormSection extends BloodDrawFormSection
         }
     }
 
+    @Override
     public List<String> getTbarButtons()
     {
         List<String> defaultButtons = super.getTbarButtons();

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCasesFormPanelSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCCasesFormPanelSection.java
@@ -14,10 +14,10 @@ import java.util.List;
 
 public class NIRCCasesFormPanelSection extends ParentFormPanelSection
 {
-    private boolean isVetTech;
-    private boolean isVet;
-    private boolean isFolderAdmin;
-    private boolean isBehavior;
+    private final boolean isVetTech;
+    private final boolean isVet;
+    private final boolean isFolderAdmin;
+    private final boolean isBehavior;
 
     public NIRCCasesFormPanelSection(String label, DataEntryFormContext ctx, boolean isBehavior)
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCClinicalObservationsFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCClinicalObservationsFormSection.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class NIRCClinicalObservationsFormSection extends BaseFormSection
 {
     public static final String LABEL = "Observations";
-    private boolean _autoPopulateDailyObs = true;
+    private boolean _autoPopulateDailyObs;
 
     public NIRCClinicalObservationsFormSection(boolean autoPopulateDailyObs, boolean initCollapsed)
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCClinicalRemarksFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCClinicalRemarksFormSection.java
@@ -8,9 +8,9 @@ import java.util.List;
 public class NIRCClinicalRemarksFormSection extends BaseFormSection
 {
     public static final String LABEL = "Clinical Remarks";
-    private boolean isVetTech;
-    private boolean isVet;
-    private boolean isFolderAdmin;
+    private final boolean isVetTech;
+    private final boolean isVet;
+    private final boolean isFolderAdmin;
 
     public NIRCClinicalRemarksFormSection(boolean isVetTech, boolean isVet, boolean isFolderAdmin)
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCDeathFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCDeathFormSection.java
@@ -12,6 +12,7 @@ public class NIRCDeathFormSection extends ParentFormPanelSection
         setSupportFormSort(false);
     }
 
+    @Override
     public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
     {
         JSONObject json = super.toJSON(ctx, includeFormElements);

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCExemptionsFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCExemptionsFormSection.java
@@ -1,7 +1,5 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
-import org.labkey.api.ehr.EHRService;
-
 public class NIRCExemptionsFormSection extends BaseFormSection
 {
     public NIRCExemptionsFormSection(String label)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCFlagsFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCFlagsFormSection.java
@@ -1,7 +1,5 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
-import org.labkey.api.ehr.EHRService;
-
 public class NIRCFlagsFormSection extends BaseFormSection
 {
     public NIRCFlagsFormSection(String label)

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCGrossPathologyFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCGrossPathologyFormSection.java
@@ -1,7 +1,5 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
-import org.json.JSONObject;
-import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.util.List;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCNecropsyFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCNecropsyFormSection.java
@@ -1,13 +1,9 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
 import org.json.JSONObject;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.ehr.dataentry.SimpleFormPanelSection;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.view.template.ClientDependency;
-
-import java.util.List;
 
 public class NIRCNecropsyFormSection extends SimpleFormPanelSection
 {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCObservationOrdersFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCObservationOrdersFormSection.java
@@ -8,7 +8,7 @@ public class NIRCObservationOrdersFormSection extends BaseFormSection
 {
 
     public static final String LABEL = "Observation Orders";
-    private String _dailyObsOption;
+    private final String _dailyObsOption;
 
     public NIRCObservationOrdersFormSection(String dailyObsOption, boolean initCollapsed)
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCWeightFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCWeightFormSection.java
@@ -1,6 +1,5 @@
 package org.labkey.nirc_ehr.dataentry.section;
 
-import org.labkey.api.ehr.EHRService;
 import org.labkey.api.view.template.ClientDependency;
 
 public class NIRCWeightFormSection extends BaseFormSection

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveAssignmentsDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveAssignmentsDemographicsProvider.java
@@ -35,7 +35,7 @@ public class ActiveAssignmentsDemographicsProvider extends AbstractListDemograph
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("project"));

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveCasesDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveCasesDemographicsProvider.java
@@ -21,7 +21,7 @@ public class ActiveCasesDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("objectid"));
         keys.add(FieldKey.fromString("Id"));

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveFlagsDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveFlagsDemographicsProvider.java
@@ -39,7 +39,7 @@ public class ActiveFlagsDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveTreatmentsDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ActiveTreatmentsDemographicsProvider.java
@@ -20,7 +20,7 @@ public class ActiveTreatmentsDemographicsProvider extends AbstractListDemographi
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("code"));
@@ -60,6 +60,7 @@ public class ActiveTreatmentsDemographicsProvider extends AbstractListDemographi
         return keys;
     }
 
+    @Override
     protected SimpleFilter getFilter(Collection<String> ids)
     {
         SimpleFilter filter = super.getFilter(ids);

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/NecropsyStatusDemographicsProvider.java
@@ -31,13 +31,14 @@ public class NecropsyStatusDemographicsProvider extends AbstractListDemographics
     @Override
     protected Collection<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("necropsy_status"));
 
         return keys;
     }
 
+    @Override
     protected SimpleFilter getFilter(Collection<String> ids)
     {
         List<String> qcStates = new ArrayList<>();

--- a/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ProtocolAssignmentDemographicsProvider.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/demographics/ProtocolAssignmentDemographicsProvider.java
@@ -8,7 +8,6 @@ import org.labkey.api.query.FieldKey;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class ProtocolAssignmentDemographicsProvider extends AbstractListDemographicsProvider

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/BloodDrawDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/BloodDrawDataSource.java
@@ -41,12 +41,11 @@ public class BloodDrawDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Total Quantity", "quantity", " mL"));
-        sb.append(safeAppend(rs, "Sample Type", "type"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Total Quantity", "quantity", " mL") +
+                safeAppend(rs, "Sample Type", "type") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/BreederDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/BreederDataSource.java
@@ -32,12 +32,11 @@ public class BreederDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Type", "type"));
-        sb.append(safeAppend(rs, "Result", "result"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Type", "type") +
+                safeAppend(rs, "Result", "result") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/FosteringDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/FosteringDataSource.java
@@ -40,11 +40,10 @@ public class FosteringDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Type", "type"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Type", "type") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/HistopathologyDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/HistopathologyDataSource.java
@@ -40,11 +40,10 @@ public class HistopathologyDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Diagnosis", "diagnosis"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Diagnosis", "diagnosis") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCCaseCloseDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCCaseCloseDataSource.java
@@ -1,6 +1,5 @@
 package org.labkey.nirc_ehr.history;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -31,14 +30,12 @@ public class NIRCCaseCloseDataSource extends AbstractDataSource
     {
         Date start = rs.getDate(FieldKey.fromString("date"));
 
-        StringBuilder sb = new StringBuilder();
+        String sb = "Opened Date: " + DateUtil.formatDate(c, start) +
+                "\n" +
+                safeAppend(rs, "Problem Area", "problemCategory") +
+                safeAppend(rs, "Close Remark", "closeRemark");
 
-        sb.append("Opened Date: ").append(DateUtil.formatDate(c, start));
-        sb.append("\n");
-        sb.append(safeAppend(rs, "Problem Area", "problemCategory"));
-        sb.append(safeAppend(rs, "Close Remark", "closeRemark"));
-
-        return sb.toString();
+        return sb;
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCClinicalObservationsDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCClinicalObservationsDataSource.java
@@ -59,7 +59,7 @@ public class NIRCClinicalObservationsDataSource extends AbstractDataSource
                 rowMap.put("html", html);
 
                 Date roundedDate = DateUtils.truncate((Date)rowMap.get("date"), Calendar.MINUTE);
-                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate.toString();
+                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate;
                 List<Map<String, Object>> obsRows = idMap.get(key);
                 if (obsRows == null)
                     obsRows = new ArrayList<>();
@@ -112,11 +112,8 @@ public class NIRCClinicalObservationsDataSource extends AbstractDataSource
             }
 
             HistoryRow row = new HistoryRowImpl(this, categoryText, categoryGroup, categoryColor, subjectId, date, html.toString(), qcStateLabel, publicData, taskId, taskRowId, formType, objectId);
-            if (row != null)
-            {
-                row.setShowTime(false);
-                rows.add(row);
-            }
+            row.setShowTime(false);
+            rows.add(row);
         }
 
         return rows;
@@ -158,12 +155,12 @@ public class NIRCClinicalObservationsDataSource extends AbstractDataSource
 
         if (rs.getString(FieldKey.fromString("remark")) != null)
         {
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sb.append(".  ");
             sb.append(PageFlowUtil.filter(rs.getString(FieldKey.fromString("remark"))));
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
             sb.append("\n");
 
         return sb.toString();

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCObservationOrdersDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/NIRCObservationOrdersDataSource.java
@@ -59,7 +59,7 @@ public class NIRCObservationOrdersDataSource extends AbstractDataSource
                 rowMap.put("html", html);
 
                 Date roundedDate = DateUtils.truncate((Date)rowMap.get("date"), Calendar.MINUTE);
-                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate.toString();
+                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate;
                 List<Map<String, Object>> obsRows = idMap.get(key);
                 if (obsRows == null)
                     obsRows = new ArrayList<>();
@@ -112,11 +112,8 @@ public class NIRCObservationOrdersDataSource extends AbstractDataSource
             }
 
             HistoryRow row = new HistoryRowImpl(this, categoryText, categoryGroup, categoryColor, subjectId, date, html.toString(), qcStateLabel, publicData, taskId, taskRowId, formType, objectId);
-            if (row != null)
-            {
-                row.setShowTime(false);
-                rows.add(row);
-            }
+            row.setShowTime(false);
+            rows.add(row);
         }
 
         return rows;
@@ -148,12 +145,12 @@ public class NIRCObservationOrdersDataSource extends AbstractDataSource
 
         if (rs.getString(FieldKey.fromString("remark")) != null)
         {
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sb.append(".  ");
             sb.append(PageFlowUtil.filter(rs.getString(FieldKey.fromString("remark"))));
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
             sb.append("\n");
 
         return sb.toString();

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/ProtocolDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/ProtocolDataSource.java
@@ -48,6 +48,6 @@ public class ProtocolDataSource extends AbstractDataSource
         sb.append(displayLabel);
         sb.append(": ");
         sb.append(PageFlowUtil.filter(value));
-        sb.append("\n");;
+        sb.append("\n");
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/notification/TriggerScriptNotification.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/notification/TriggerScriptNotification.java
@@ -49,7 +49,7 @@ public class TriggerScriptNotification
                 }
             }
 
-            if (emails.size() == 0)
+            if (emails.isEmpty())
             {
                 _log.warn("No emails, unable to send EHR trigger script email");
                 return;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -61,12 +61,12 @@ import java.util.Set;
 
 public class NIRC_EHRTriggerHelper
 {
-    private Container _container = null;
-    private User _user = null;
+    private Container _container;
+    private User _user;
     private static final Logger _log = LogManager.getLogger(NIRC_EHRTriggerHelper.class);
-    private Map<String,Object> _cachedDrugFormulary = new HashMap<>();
+    private final Map<String,Object> _cachedDrugFormulary = new HashMap<>();
 
-    private SimpleDateFormat _dateFormat;
+    private final SimpleDateFormat _dateFormat;
 
     public NIRC_EHRTriggerHelper(int userId, String containerId)
     {
@@ -144,7 +144,7 @@ public class NIRC_EHRTriggerHelper
             nextFilter.addCondition(FieldKey.fromString("taskid"), taskId, CompareType.NEQ); // Don't include the current record
             TableSelector ts = new TableSelector(ti, PageFlowUtil.set("date"), nextFilter, new Sort("date"));
             List<Date> dates = ts.getArrayList(Date.class);
-            if (dates.size() > 0)
+            if (!dates.isEmpty())
                 enddate = dates.get(0);
         }
 
@@ -359,7 +359,7 @@ public class NIRC_EHRTriggerHelper
 
                         // get recipients
                         Set<UserPrincipal> recipients = NotificationService.get().getRecipients(notification, container);
-                        if (recipients.size() == 0)
+                        if (recipients.isEmpty())
                         {
                             _log.warn("No NIRC recipients set, skipping clinical move notification");
                             return;
@@ -406,7 +406,7 @@ public class NIRC_EHRTriggerHelper
 
                         // get recipients
                         Set<UserPrincipal> recipients = NotificationService.get().getRecipients(new NIRCDeathNotification(), container);
-                        if (recipients.size() == 0)
+                        if (recipients.isEmpty())
                         {
                             _log.warn("No NIRC recipients set, skipping death notification");
                             return;
@@ -930,7 +930,7 @@ public class NIRC_EHRTriggerHelper
                         //get pregnancy outcome info
                         Date date = ConvertHelper.convert(row.get("date"), Date.class);
                         String result = ConvertHelper.convert(row.get("result"), String.class);
-                        String outcome = null;
+                        String outcome;
                         try
                         {
                             outcome = getPregnancyResultTitle(result);

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -82,22 +82,22 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
     private static final String PROJECT_NAME = "NIRC";
     private static final String PROJECT_TYPE = "NIRC EHR";
     private static final File orchardFileLocation = TestFileUtils.getTestTempDir();
-    private static String NIRC_BASIC_SUBMITTER = "ac_bs@nirctest.com";
-    private static String NIRC_BASIC_SUBMITTER_NAME = "ac bs";
-    private static String NIRC_BASIC_SUBMITTER_VET_TECH = "vet_tech_bs@nirctest.com";
-    private static String NIRC_FULL_SUBMITTER_VET_TECH = "vet_tech_fs@nirctest.com";
-    private static String NIRC_FULL_SUBMITTER_VET = "vet_fs@nirctest.com";
-    private static String NIRC_VET_NAME = "vet fs";
+    private static final String NIRC_BASIC_SUBMITTER = "ac_bs@nirctest.com";
+    private static final String NIRC_BASIC_SUBMITTER_NAME = "ac bs";
+    private static final String NIRC_BASIC_SUBMITTER_VET_TECH = "vet_tech_bs@nirctest.com";
+    private static final String NIRC_FULL_SUBMITTER_VET_TECH = "vet_tech_fs@nirctest.com";
+    private static final String NIRC_FULL_SUBMITTER_VET = "vet_fs@nirctest.com";
+    private static final String NIRC_VET_NAME = "vet fs";
 
-    private static String deadAnimalId = "D5454";
-    private static String departedAnimalId = "H6767";
-    private static String aliveAnimalId = "A4545";
+    private static final String deadAnimalId = "D5454";
+    private static final String departedAnimalId = "H6767";
+    private static final String aliveAnimalId = "A4545";
     DateTimeFormatter _dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @BeforeClass
     public static void setupProject() throws Exception
     {
-        NIRC_EHRTest init = (NIRC_EHRTest) getCurrentTest();
+        NIRC_EHRTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -116,6 +116,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         return id.toUpperCase();
     }
 
+    @Override
     @LogMethod
     protected void populateProtocolRecords() throws Exception
     {
@@ -218,7 +219,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
     private void populateFormulary() throws IOException, CommandException
     {
         InsertRowsCommand insertRowsCommand = new InsertRowsCommand("ehr_lookups", "drug_defaults");
-        insertRowsCommand.addRow(new HashMap<String, Object>()
+        insertRowsCommand.addRow(new HashMap<>()
         {
             {
                 put("code", "NIRC-001");
@@ -853,7 +854,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         waitForText("Diazepam");
         waitForText(animalId);
         waitForTextToDisappear("Id is required");
-        orderGrid = _helper.getExt4GridForFormSection("Medications/Treatments Given");
+        _helper.getExt4GridForFormSection("Medications/Treatments Given");
         submitForm("Submit Final", "Finalize");
         stopImpersonating();
 
@@ -1099,7 +1100,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         try
         {
             // Use Files.walkFileTree to traverse the directory
-            Files.walkFileTree(orchardFileLocation.toPath(), new SimpleFileVisitor<Path>()
+            Files.walkFileTree(orchardFileLocation.toPath(), new SimpleFileVisitor<>()
             {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


