### PR TITLE
Ticket 53312: Bulk editing "Ordered By" in treatments

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/BehavioralCase.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/BehavioralCase.js
@@ -97,18 +97,6 @@ EHR.model.DataModelManager.registerMetadata('BehavioralCase', {
             caseCategory: {
                 hidden: true
             },
-            performedby: {
-                hidden: false,
-                defaultValue: LABKEY.Security.currentUser.id.toString(),
-                editorConfig: {
-                    store: {
-                        type: 'labkey-store',
-                        schemaName: 'core',
-                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName,FirstName,LastName FROM core.users',
-                        autoLoad: true
-                    }
-                }
-            },
             formCasesLink: {
                 xtype: 'nirc_ehr-editCases'
             }

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/BulkBehavior.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/BulkBehavior.js
@@ -43,19 +43,7 @@ EHR.model.DataModelManager.registerMetadata('BulkBehavior', {
             },
             qcstate: {
                 hidden: true
-            },
-            performedby: {
-                hidden: false,
-                defaultValue: LABKEY.Security.currentUser.id.toString(),
-                editorConfig: {
-                    store: {
-                        type: 'labkey-store',
-                        schemaName: 'core',
-                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName,FirstName,LastName FROM core.users',
-                        autoLoad: true
-                    }
-                }
-            },
+            }
         },
         'study.clinical_observations': {
             type: {

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/BulkClinical.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/BulkClinical.js
@@ -36,19 +36,7 @@ EHR.model.DataModelManager.registerMetadata('BulkClinical', {
                 columnConfig: {
                     editable: false
                 }
-            },
-            performedby: {
-                hidden: false,
-                defaultValue: LABKEY.Security.currentUser.id.toString(),
-                editorConfig: {
-                    store: {
-                        type: 'labkey-store',
-                        schemaName: 'core',
-                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName,FirstName,LastName FROM core.users',
-                        autoLoad: true
-                    }
-                }
-            },
+            }
         }
     }
 });

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalCase.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalCase.js
@@ -97,18 +97,6 @@ EHR.model.DataModelManager.registerMetadata('ClinicalCase', {
             caseCategory: {
                 hidden: true
             },
-            performedby: {
-                hidden: false,
-                defaultValue: LABKEY.Security.currentUser.id.toString(),
-                editorConfig: {
-                    store: {
-                        type: 'labkey-store',
-                        schemaName: 'core',
-                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName,FirstName,LastName FROM core.users',
-                        autoLoad: true
-                    }
-                }
-            },
             formCasesLink: {
                 xtype: 'nirc_ehr-editCases'
             }

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/ClinicalDefaults.js
@@ -100,23 +100,6 @@ EHR.model.DataModelManager.registerMetadata('ClinicalDefaults', {
                 defaultValue: 'Clinical',
                 hidden: true
             },
-            performedby: {
-                hidden: false,
-                defaultValue: LABKEY.Security.currentUser.id.toString(),
-                editorConfig: {
-                    store: {
-                        type: 'labkey-store',
-                        schemaName: 'core',
-
-                        // 'performedby' is a text field in the dataset and its lookup to the userid is an int field - this mismatch causes it to disappear
-                        // from the display when a value is selected from the dropdown even though the 'userid' value gets saved as a text (this behavior was only seen
-                        // in the form panel but not in the grid panel).
-                        // casting it as a varchar when loading the store fixes this issue.
-                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName,FirstName,LastName FROM core.users',
-                        autoLoad: true
-                    }
-                }
-            },
             category: {
                 defaultValue: 'Clinical',
                 hidden: true,

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
@@ -11,7 +11,7 @@ EHR.model.DataModelManager.registerMetadata('Default', {
         },
         performedby: {
             hidden: false,
-            defaultValue: LABKEY.Security.currentUser.id.toString(),
+            defaultValue: LABKEY.Security.currentUser.id,
             getInitialValue: function (v, rec) {
                 return LABKEY.Security.currentUser.id;
             },
@@ -35,6 +35,18 @@ EHR.model.DataModelManager.registerMetadata('Default', {
             defaultValue: null,
             columnConfig: {
                 width: 160
+            },
+            editorConfig: {
+                store: {
+                    type: 'labkey-store',
+                    schemaName: 'ehr_lookups',
+
+                    // 'orderedby' is a text field in the dataset and its lookup to the userid is an int field - this mismatch causes it to disappear
+                    // from the display when a value is selected from the dropdown even though the 'userid' value gets saved as a text.
+                    // Casting it as a varchar when loading the store fixes this issue.
+                    sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName FROM ehr_lookups.veterinarians',
+                    autoLoad: true
+                }
             }
         },
         scheduleddate: {
@@ -151,6 +163,16 @@ EHR.model.DataModelManager.registerMetadata('Default', {
             endTreatmentOrderedBy: {
                 columnConfig: {
                     width: 200
+                },
+                editorConfig: {
+                    store: {
+                        type: 'labkey-store',
+                        schemaName: 'ehr_lookups',
+
+                        // see 'orderedby' comment above.
+                        sql: 'SELECT CAST (UserId AS VARCHAR) AS UserId,DisplayName FROM ehr_lookups.veterinarians',
+                        autoLoad: true
+                    }
                 }
             }
         },

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -836,9 +836,16 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         orderGrid.setGridCell(1, "frequency", "QID");
         orderGrid.clickDownArrowOnGrid(1, "route");
         orderGrid.setGridCell(1, "route", "IVAG");
-        orderGrid.clickDownArrowOnGrid(1, "orderedby");
-        orderGrid.setGridCell(1, "orderedby", NIRC_VET_NAME);
         orderGrid.completeEdit();
+
+        Locator.XPathLocator bulkEditWindow = _helper.openBulkEdit(orderGrid);
+        _helper.toggleBulkEditExactField("Ordered By");
+        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithLabelContaining("Ordered By:"), NIRC_VET_NAME);
+        waitAndClick(bulkEditWindow.append(Ext4Helper.Locators.ext4Button("Submit")));
+
+        Window msgWindow = new Window.WindowFinder(this.getDriver()).withTitle("Set Values").waitFor();
+        msgWindow.clickButton("Yes", 0);
+
         submitForm("Submit Final", "Finalize Form");
 
         log("Completing today's Medication Schedule");
@@ -857,7 +864,6 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         submitForm("Submit Final", "Finalize");
         stopImpersonating();
 
-        // TODO: This will be reimplemented in a current PR, this can than be uncommented.
         //Go to NIRC/EHR main page
         goToEHRFolder();
         impersonate(NIRC_FULL_SUBMITTER_VET);


### PR DESCRIPTION
#### Rationale
The user columns such as OrderedBy and EndTreatmentOrderedBy need special handling in the store due to type mismatch. The type mismatch is to accommodate user selection or type in values.

Also removed some performedBy overrides that were not needed.

#### Changes
* Add store handling in the editor config for orderedby and endtreatmentorderedby
* Remove redundant performedby metadata
