### PR TITLE
Rename SaveRowsResponse to RowsResponse

### DIFF
--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -27,7 +27,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.core.SaveModulePropertiesCommand;
 import org.labkey.remoteapi.query.ImportDataCommand;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.security.CreateUserResponse;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -226,7 +226,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
             }
         });
 
-        SaveRowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
+        RowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83

#### Changes
- Rename `SaveRowsResponse` to `RowsResponse`
