### PR TITLE
Discard forms

### DIFF
--- a/nirc_ehr/resources/queries/dbo/q_clinremarks.sql
+++ b/nirc_ehr/resources/queries/dbo/q_clinremarks.sql
@@ -5,8 +5,7 @@ SELECT anmEvt.ANIMAL_EVENT_ID                                                   
             WHEN (trim(anmEvt.STAFF_ID.STAFF_FIRST_NAME) IS NULL OR trim(anmEvt.STAFF_ID.STAFF_LAST_NAME) IS NULL) THEN 'unknown'
             ELSE (trim(anmEvt.STAFF_ID.STAFF_FIRST_NAME)
                 || '|' || trim(anmEvt.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
-       anmEvt.DIAGNOSIS                                                          AS vetreview,
-       anmCmt.TEXT                                                               AS remark,
+       ('Note: ' || COALESCE(anmCmt.TEXT, 'None') || '; Diagnosis: ' || COALESCE(anmEvt.DIAGNOSIS, 'None')) AS remark,
        'Clinical'                                                                AS category,
        CASE WHEN anmEvt.ATTACHMENT_PATH IS NOT NULL THEN
             ('C:\Program Files\Labkey\labkey\files\NIRC\EHR\@files\attachments'

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBaseTaskFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBaseTaskFormType.java
@@ -36,7 +36,6 @@ public class NIRCBaseTaskFormType extends TaskForm
     {
         List<String> configs = super.getMoreActionButtonConfigs();
         configs.remove("REVIEW");
-        configs.remove("DISCARD");
         return configs;
     }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBehaviorRoundsFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBehaviorRoundsFormType.java
@@ -93,4 +93,12 @@ public class NIRCBehaviorRoundsFormType extends NIRCBaseTaskFormType
 
         return ret;
     }
+
+    @Override
+    protected List<String> getMoreActionButtonConfigs()
+    {
+        List<String> configs = super.getMoreActionButtonConfigs();
+        configs.remove("DISCARD");
+        return configs;
+    }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBehavioralCasesFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCBehavioralCasesFormType.java
@@ -97,4 +97,12 @@ public class NIRCBehavioralCasesFormType extends NIRCBaseTaskFormType
 
         return ret;
     }
+
+    @Override
+    protected List<String> getMoreActionButtonConfigs()
+    {
+        List<String> configs = super.getMoreActionButtonConfigs();
+        configs.remove("DISCARD");
+        return configs;
+    }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCCasesFormType.java
@@ -109,4 +109,12 @@ public class NIRCCasesFormType extends NIRCBaseTaskFormType
 
         return ret;
     }
+
+    @Override
+    protected List<String> getMoreActionButtonConfigs()
+    {
+        List<String> configs = super.getMoreActionButtonConfigs();
+        configs.remove("DISCARD");
+        return configs;
+    }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCClinicalRoundsFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCClinicalRoundsFormType.java
@@ -101,4 +101,12 @@ public class NIRCClinicalRoundsFormType extends NIRCBaseTaskFormType
 
         return ret;
     }
+
+    @Override
+    protected List<String> getMoreActionButtonConfigs()
+    {
+        List<String> configs = super.getMoreActionButtonConfigs();
+        configs.remove("DISCARD");
+        return configs;
+    }
 }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCDeathNecropsyFormType.java
@@ -63,4 +63,12 @@ public class NIRCDeathNecropsyFormType extends NIRCBaseTaskFormType
         }
         return defaultButtons;
     }
+
+    @Override
+    protected List<String> getMoreActionButtonConfigs()
+    {
+        List<String> configs = super.getMoreActionButtonConfigs();
+        configs.remove("DISCARD");
+        return configs;
+    }
 }


### PR DESCRIPTION
#### Rationale
Add ability to discard forms to all non-case or necropsy related forms. Update clinremarks ETL to concat comment and diagnosis similar to cases.