### PR TITLE
Add owner module to notifications

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -184,10 +184,10 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
         EHRService.get().registerMoreActionsButton(new MarkCompletedButton(this, "study", "flags", "Set End Date"), "study", "flags");
 
         registerDataEntry();
-        NotificationService.get().registerNotification(new NIRCDeathNotification());
-        NotificationService.get().registerNotification(new NIRCClinicalMoveNotification());
-        NotificationService.get().registerNotification(new NIRCProcedureOverdueNotification());
-        NotificationService.get().registerNotification(new NIRCPregnancyOutcomeNotification());
+        NotificationService.get().registerNotification(new NIRCDeathNotification(this));
+        NotificationService.get().registerNotification(new NIRCClinicalMoveNotification(this));
+        NotificationService.get().registerNotification(new NIRCProcedureOverdueNotification(this));
+        NotificationService.get().registerNotification(new NIRCPregnancyOutcomeNotification(this));
 
         EHRService.get().registerReportLink(EHRService.REPORT_LINK_TYPE.moreReports, "Printable Necropsy Report", this, DetailsURL.fromString("/nirc_ehr-necropsy.view"), "Pathology");
 

--- a/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCClinicalMoveNotification.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCClinicalMoveNotification.java
@@ -3,12 +3,23 @@ package org.labkey.nirc_ehr.notification;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.ehr.notification.AbstractEHRNotification;
+import org.labkey.api.module.Module;
 import org.labkey.api.security.User;
 
 import java.util.Date;
 
 public class NIRCClinicalMoveNotification extends AbstractEHRNotification
 {
+    public NIRCClinicalMoveNotification(Module owner)
+    {
+        super(owner);
+    }
+
+    public NIRCClinicalMoveNotification()
+    {
+        super();
+    }
+
     @Override
     public String getName()
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCDeathNotification.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCDeathNotification.java
@@ -17,12 +17,23 @@ package org.labkey.nirc_ehr.notification;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.ehr.notification.AbstractEHRNotification;
+import org.labkey.api.module.Module;
 import org.labkey.api.security.User;
 
 import java.util.Date;
 
 public class NIRCDeathNotification extends AbstractEHRNotification
 {
+    public NIRCDeathNotification(Module owner)
+    {
+        super(owner);
+    }
+
+    public NIRCDeathNotification()
+    {
+        super();
+    }
+
     @Override
     public String getName()
     {

--- a/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCPregnancyOutcomeNotification.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCPregnancyOutcomeNotification.java
@@ -17,16 +17,27 @@ package org.labkey.nirc_ehr.notification;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.ehr.notification.AbstractEHRNotification;
+import org.labkey.api.module.Module;
 import org.labkey.api.security.User;
 
 import java.util.Date;
 
 public class NIRCPregnancyOutcomeNotification extends AbstractEHRNotification
 {
+    public NIRCPregnancyOutcomeNotification(Module owner)
+    {
+        super(owner);
+    }
+
+    public NIRCPregnancyOutcomeNotification()
+    {
+        super();
+    }
+
     @Override
     public String getName()
     {
-        return "NIRC Pregnancy Outcome Notification";
+        return "Pregnancy Outcome Notification";
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCProcedureOverdueNotification.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/notification/NIRCProcedureOverdueNotification.java
@@ -5,6 +5,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.notification.AbstractEHRNotification;
+import org.labkey.api.module.Module;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -17,10 +18,15 @@ import java.util.Set;
 
 public class NIRCProcedureOverdueNotification extends AbstractEHRNotification
 {
+    public NIRCProcedureOverdueNotification(Module owner)
+    {
+        super(owner);
+    }
+
     @Override
     public String getName()
     {
-        return "NIRC Procedure Overdue Notification";
+        return "Procedure Overdue Notification";
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This mostly affects development environments with multiple EHR modules. Scope these notifications to NIRC.

#### Changes
* Owner constructors
* Pass in NIRCModule
