### PR TITLE
Ticket 53843: Arrivals error message on duplicate IDs

### DIFF
--- a/nirc_ehr/resources/queries/study/arrival.js
+++ b/nirc_ehr/resources/queries/study/arrival.js
@@ -12,6 +12,10 @@ function onInit(event, helper){
 }
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
 
+    if (triggerHelper.animalIdExists(row.Id)) {
+        EHR.Server.Utils.addError(scriptErrors, 'Id', 'Animal Id ' + row.Id + ' is already in use. Please use a different Id.', 'ERROR');
+    }
+
     if (row.eventDate) {
         row.date = row.eventDate;
     }

--- a/nirc_ehr/resources/queries/study/arrival.js
+++ b/nirc_ehr/resources/queries/study/arrival.js
@@ -10,11 +10,15 @@ function onInit(event, helper){
         skipAssignmentCheck: true,
     });
 }
-EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
 
     if (triggerHelper.animalIdExists(row.Id)) {
         EHR.Server.Utils.addError(scriptErrors, 'Id', 'Animal Id ' + row.Id + ' is already in use. Please use a different Id.', 'ERROR');
     }
+});
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
 
     if (row.eventDate) {
         row.date = row.eventDate;

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -264,6 +264,18 @@ public class NIRC_EHRTriggerHelper
         return null;
     }
 
+    public boolean animalIdExists(String id)
+    {
+        TableInfo ti = getTableInfo("study", "demographics");
+        if (ti != null)
+        {
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), id);
+            TableSelector ts = new TableSelector(ti, PageFlowUtil.set("lsid"), filter, null);
+            return ts.exists();
+        }
+        return false;
+    }
+
     public boolean birthExists(String id)
     {
         TableInfo ti = getTableInfo("study", "birth");
@@ -275,6 +287,7 @@ public class NIRC_EHRTriggerHelper
         }
         return false;
     }
+
     public boolean deathExists(String id)
     {
         TableInfo ti = getTableInfo("study", "deaths");


### PR DESCRIPTION
#### Rationale
Ticket [53843](https://www.labkey.org/NIRC/Support%20Tickets/issues-details.view?issueId=53843): Arrivals error message on duplicate IDs

Arrivals data entry allows 'Submit For Review' even when that Id already exists, but the submission then fails with an unhelpful error message. This PR prevents form submission when a duplicate Id is detected and shows a clear Error message.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Error for a duplicate animal id