### PR TITLE
QCState checks on queries

### DIFF
--- a/nirc_ehr/resources/queries/study/demographicsActiveProjectAssignment.sql
+++ b/nirc_ehr/resources/queries/study/demographicsActiveProjectAssignment.sql
@@ -3,3 +3,4 @@ SELECT
   a.project.name as project
 FROM study.demographics d
 LEFT JOIN study.assignment a ON (a.id = d.id AND a.enddate IS NULL)
+WHERE a.qcstate.publicdata = true

--- a/nirc_ehr/resources/queries/study/demographicsActiveProtocolAssignment.sql
+++ b/nirc_ehr/resources/queries/study/demographicsActiveProtocolAssignment.sql
@@ -11,3 +11,4 @@ SELECT
 
 FROM study.demographics d
 LEFT JOIN study.protocolAssignment a ON (a.id = d.id AND a.enddate IS NULL)
+WHERE a.qcstate.publicdata = true

--- a/nirc_ehr/resources/queries/study/demographicsCagemates.sql
+++ b/nirc_ehr/resources/queries/study/demographicsCagemates.sql
@@ -20,7 +20,7 @@ JOIN study.housing h2
 ON (h2.Id.demographics.calculated_status = 'Alive'
         AND (h.cage = h2.cage))
 
-WHERE h.enddateTimeCoalesced >= now()
+WHERE h.enddateTimeCoalesced >= now() AND h.qcstate.publicdata = true AND h2.qcstate.publicdata = true
 GROUP BY h.id, h.room, h.cage
 
 ) t ON (t.id = d.id)

--- a/nirc_ehr/resources/queries/study/demographicsCurLocation.sql
+++ b/nirc_ehr/resources/queries/study/demographicsCurLocation.sql
@@ -33,5 +33,5 @@ d2.performedBy.displayName AS performedBy
 
 FROM study.housing d2
 
-WHERE d2.enddate IS NULL
+WHERE d2.enddate IS NULL AND d2.qcstate.publicdata = true
 AND d2.qcstate.publicdata = true

--- a/nirc_ehr/resources/queries/study/demographicsOffspring.sql
+++ b/nirc_ehr/resources/queries/study/demographicsOffspring.sql
@@ -17,5 +17,6 @@ FROM study.Demographics d
 
     INNER JOIN study.Demographics d2
 ON ((d2.sire = d.id OR d2.dam = d.id) AND d.id != d2.id)
+WHERE d.qcstate.publicdata = true
 
 group by d.id, d2.id, d2.birth, d2.sire, d2.dam, d2.gender, d.qcstate

--- a/nirc_ehr/resources/queries/study/demographicsParents.sql
+++ b/nirc_ehr/resources/queries/study/demographicsParents.sql
@@ -25,6 +25,7 @@ SELECT
         ELSE 0
         END as numParents
 FROM study.demographics d
+WHERE d.qcstate.publicdata = true
 
 -- TODO: Incorporate fostering? Genetic testing?
 

--- a/nirc_ehr/resources/queries/study/demographicsSiblings.sql
+++ b/nirc_ehr/resources/queries/study/demographicsSiblings.sql
@@ -30,7 +30,7 @@ FROM study.Demographics d1
          JOIN study.Demographics d2
               ON ((d2.id.parents.sire = d1.id.parents.sire OR d2.id.parents.dam = d1.id.parents.dam) AND d1.id != d2.id)
 
-WHERE d2.id is not null
+WHERE d2.id IS NOT NULL AND d1.qcstate.publicdata = true AND d2.qcstate.publicdata = true
 
 -- ) t
 

--- a/nirc_ehr/resources/queries/study/demographicsSource.sql
+++ b/nirc_ehr/resources/queries/study/demographicsSource.sql
@@ -27,4 +27,5 @@ LEFT JOIN
   ON (T1.Id = d.Id)
 
 LEFT JOIN study.arrival T2 ON (t2.id = d.id AND t2.date = t1.earliestArrival)
+WHERE d.qcstate.publicdata = true AND t2.qcstate.publicdata = true AND t1.qcstate.publicdata = true
 

--- a/nirc_ehr/resources/queries/study/demographicsSource.sql
+++ b/nirc_ehr/resources/queries/study/demographicsSource.sql
@@ -27,5 +27,5 @@ LEFT JOIN
   ON (T1.Id = d.Id)
 
 LEFT JOIN study.arrival T2 ON (t2.id = d.id AND t2.date = t1.earliestArrival)
-WHERE d.qcstate.publicdata = true AND t2.qcstate.publicdata = true AND t1.qcstate.publicdata = true
+WHERE d.qcstate.publicdata = true AND t2.qcstate.publicdata = true
 


### PR DESCRIPTION
#### Rationale
Add qcstate isPublic check on several queries.

#### Changes
* Update pedigree, housing and assignment queries
