### PR TITLE
Performedby ETL fixes

### DIFF
--- a/nirc_ehr/resources/etls/ProjectAndAssignment.xml
+++ b/nirc_ehr/resources/etls/ProjectAndAssignment.xml
@@ -20,6 +20,7 @@
                          bulkLoad="true" batchSize="5000" targetOption="truncate">
                 <columnTransforms>
                     <column source="assignmentDate" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>
                 </columnTransforms>
             </destination>
         </transform>

--- a/nirc_ehr/resources/etls/birth.xml
+++ b/nirc_ehr/resources/etls/birth.xml
@@ -13,6 +13,7 @@
                 </alternateKeys>
                 <columnTransforms>
                     <column source="birthDate" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>
                 </columnTransforms>
             </destination>
         </transform>

--- a/nirc_ehr/resources/etls/deaths.xml
+++ b/nirc_ehr/resources/etls/deaths.xml
@@ -13,6 +13,7 @@
                 </alternateKeys>
                 <columnTransforms>
                     <column source="deathDate" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>
                 </columnTransforms>
             </destination>
         </transform>

--- a/nirc_ehr/resources/etls/demographics.xml
+++ b/nirc_ehr/resources/etls/demographics.xml
@@ -13,6 +13,7 @@
                 </alternateKeys>
                 <columnTransforms>
                     <column source="BIRTH_DATE" target="date"/>
+                    <column source="performedby" target="performedby" transformClass="org.labkey.nirc_ehr.columnTransform.NIRCUserCreateTransform"/>
                 </columnTransforms>
             </destination>
         </transform>

--- a/nirc_ehr/resources/queries/dbo/q_births.sql
+++ b/nirc_ehr/resources/queries/dbo/q_births.sql
@@ -1,5 +1,9 @@
 SELECT anm.ANIMAL_ID_NUMBER AS participantId,
        anm.BIRTH_DATE       AS birthDate,
+       (CASE
+            WHEN (ae.STAFF_ID.STAFF_FIRST_NAME IS NULL OR ae.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
+            ELSE (trim(ae.STAFF_ID.STAFF_FIRST_NAME)
+                || '|' || trim(ae.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
        -- audit timestamp for modifications or animal event received for created
        COALESCE(MAX(CAST(adt.CHANGE_DATETIME AS TIMESTAMP)), ae.CREATED_DATETIME) AS modified
 FROM Animal anm
@@ -12,4 +16,6 @@ AND anm.ANIMAL_ID_NUMBER LIKE 'A%' -- Animal born in centers are pre-appended wi
 AND alt.DESCRIPTION IS NOT NULL
 GROUP BY anm.ANIMAL_ID_NUMBER,
          anm.BIRTH_DATE,
+         ae.STAFF_ID.STAFF_FIRST_NAME,
+         ae.STAFF_ID.STAFF_LAST_NAME,
          ae.CREATED_DATETIME

--- a/nirc_ehr/resources/queries/dbo/q_deaths.sql
+++ b/nirc_ehr/resources/queries/dbo/q_deaths.sql
@@ -2,6 +2,10 @@
 SELECT an.ANIMAL_ID_NUMBER AS participantId,
        an.DEATH_DATE AS deathDate,
        an.TERMINATION_REASON_ID as reason,
+       (CASE
+            WHEN (ae.STAFF_ID.STAFF_FIRST_NAME IS NULL OR ae.STAFF_ID.STAFF_LAST_NAME IS NULL) THEN 'unknown'
+            ELSE (trim(ae.STAFF_ID.STAFF_FIRST_NAME)
+                || '|' || trim(ae.STAFF_ID.STAFF_LAST_NAME)) END)                  AS performedby,
        COALESCE(MAX(CAST(adt.CHANGE_DATETIME AS TIMESTAMP)), ae.CREATED_DATETIME) AS modified
 FROM Animal an
 LEFT JOIN AUDIT_TRAIL adt ON an.ANIMAL_ID = substring(PRIMARY_KEY_VALUES, length('ANIMAL_ID = '))
@@ -12,4 +16,6 @@ AND an.TERMINATION_REASON_ID != 10 -- Invalid Id
 GROUP BY an.ANIMAL_ID_NUMBER,
     an.DEATH_DATE,
     an.TERMINATION_REASON_ID,
+    ae.STAFF_ID.STAFF_FIRST_NAME,
+    ae.STAFF_ID.STAFF_LAST_NAME,
     ae.CREATED_DATETIME

--- a/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRSharedDatasetTrigger.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRSharedDatasetTrigger.java
@@ -26,11 +26,7 @@ public class NIRC_EHRSharedDatasetTrigger implements Trigger
     {
         if (newRow != null && newRow.containsKey("performedby") && newRow.get("performedby") == null)
         {
-            if (!newRow.containsKey("QCStateLabel") || newRow.get("QCStateLabel") == null)
-            {
-                errors.addFieldError("performedby", "Record in " + table.getTitle() + " cannot be submitted without Performed By if QCStateLabel is not found. Contact your administrator.");
-            }
-            else if (newRow.containsKey("QCStateLabel") && newRow.get("QCStateLabel").equals("Completed"))
+            if (newRow.containsKey("QCStateLabel") && "Completed".equals(newRow.get("QCStateLabel")))
             {
                 errors.addFieldError("performedby", "Performed By must be entered in all records before submitting final. Table: " + table.getTitle());
             }


### PR DESCRIPTION
#### Rationale
Birth and death ETLs need performedby. Add performedby transform class

#### Changes
* Birth and death source queries
* performedby ETL transforms
