### PR TITLE
Update procedure order status on death/departure

### DIFF
--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -142,5 +142,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
         if (!helper.isETL() && event === 'insert') {
             triggerHelper.sendDeathNotification(ids[0]);
         }
+
+        triggerHelper.updateProcedureOrdersToCompleted(ids);
     }
 });

--- a/nirc_ehr/resources/queries/study/departure.js
+++ b/nirc_ehr/resources/queries/study/departure.js
@@ -1,9 +1,26 @@
 require("ehr/triggers").initScript(this);
 
+var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
+var departures = [];
+
 function onInit(event, helper){
     helper.setScriptOptions({
         requiresStatusRecalc: false
     });
 
 }
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'departure', function(helper, scriptErrors, row, oldRow) {
+
+    if (row.id) {
+        departures.push(row.id);
+    }
+});
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.COMPLETE, 'study', 'departure', function(event, errors, helper){
+
+    if (!helper.isETL() && helper.isEHRDataEntry()) {
+        triggerHelper.updateProcedureOrdersToCompleted(departures);
+    }
+});
 

--- a/nirc_ehr/resources/queries/study/prcOverdue.query.xml
+++ b/nirc_ehr/resources/queries/study/prcOverdue.query.xml
@@ -7,7 +7,9 @@
                 <columns>
                     <column columnName="objectid">
                         <isHidden>true</isHidden>
-                        <isKeyField>true</isKeyField>
+                    </column>
+                    <column columnName="lsid">
+                        <isHidden>true</isHidden>
                     </column>
                     <column columnName="Id">
                         <fk>

--- a/nirc_ehr/resources/queries/study/prcOverdue.sql
+++ b/nirc_ehr/resources/queries/study/prcOverdue.sql
@@ -9,6 +9,7 @@ SELECT
     po.remark,
     po.caseid,
     po.objectid,
+    po.lsid,
     CASE WHEN po.qcstate.label = 'Completed' THEN 'Completed' ELSE '' END as status
 FROM prc_order po
 WHERE now() > windowEnd AND po.qcstate.label != 'Completed'

--- a/nirc_ehr/resources/queries/study/prcSchedule.query.xml
+++ b/nirc_ehr/resources/queries/study/prcSchedule.query.xml
@@ -7,7 +7,9 @@
                 <columns>
                     <column columnName="objectid">
                         <isHidden>true</isHidden>
-                        <isKeyField>true</isKeyField>
+                    </column>
+                    <column columnName="lsid">
+                        <isHidden>true</isHidden>
                     </column>
                     <column columnName="Id">
                         <fk>

--- a/nirc_ehr/resources/queries/study/prcSchedule.sql
+++ b/nirc_ehr/resources/queries/study/prcSchedule.sql
@@ -9,6 +9,7 @@ SELECT
     po.remark,
     po.caseid,
     po.objectid,
+    po.lsid,
     CASE WHEN po.qcstate.label = 'Completed' THEN 'Completed' ELSE '' END as status
 FROM prc_order po
 WHERE now() >= windowStart AND now() <= windowEnd

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/ProcedureOrderCompleteButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/ProcedureOrderCompleteButton.js
@@ -51,7 +51,7 @@ Ext4.define('NIRC_EHR.window.ProcedureOrderCompleteWindow', {
                 if (completedRowId) {
                     for (const row of selectedRows) {
                         rowsToInsert.push({
-                            objectid: row,
+                            lsid: row,
                             qcstate: completedRowId
                         });
                     }

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/RecordProcedureButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/RecordProcedureButton.js
@@ -71,14 +71,14 @@ Ext4.define('NIRC_EHR.window.RecordProcedureWindow', {
         LABKEY.Query.selectRows({
             schemaName: 'study',
             queryName: 'prc_order',
-            filterArray: [LABKEY.Filter.create('objectid', selectedRows.join(';'), LABKEY.Filter.Types.EQUALS_ONE_OF)],
+            filterArray: [LABKEY.Filter.create('lsid', selectedRows.join(';'), LABKEY.Filter.Types.EQUALS_ONE_OF)],
             scope: this,
-            columns: 'Id,objectid,procedure,category,caseid,orderedby',
+            columns: 'Id,objectid,procedure,category,caseid,orderedby,lsid',
             success: function (data) {
                 const rowsToInsert = [];
                 Ext4.each(data.rows, function(row) {
                     Ext4.each(selectedRows, function(selectedRow) {
-                        if (row.objectid === selectedRow) {
+                        if (row.lsid === selectedRow) {
                             rowsToInsert.push({
                                 Id: row.Id,
                                 procedure: row.procedure,

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -938,8 +938,8 @@ public class NIRC_EHRTriggerHelper
         TableInfo ti = getTableInfo("study", "prc_order");
 
         // Get the QC state IDs for "Request: Approved" and "Completed"
-        Integer approvedQcStateId = EHRService.get().getQCStates(_container).get("Request: Approved").getRowId();
-        Integer completedQcStateId = EHRService.get().getQCStates(_container).get("Completed").getRowId();
+        Integer approvedQcStateId = EHRService.get().getQCStates(_container).get(EHRService.QCSTATES.RequestApproved.getLabel()).getRowId();
+        Integer completedQcStateId = EHRService.get().getQCStates(_container).get(EHRService.QCSTATES.Completed.getLabel()).getRowId();
 
         // Query for rows matching the IDs and having "Request: Approved" status
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), ids, CompareType.IN);

--- a/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/query/NIRC_EHRTriggerHelper.java
@@ -927,6 +927,54 @@ public class NIRC_EHRTriggerHelper
         }
     }
 
+    public void updateProcedureOrdersToCompleted(List<String> ids)
+    {
+        if (ids == null || ids.size() < 1) // Native array doesn't support isEmpty
+        {
+            _log.warn("No IDs provided to updateProcedureOrdersToCompleted");
+            return;
+        }
+
+        TableInfo ti = getTableInfo("study", "prc_order");
+
+        // Get the QC state IDs for "Request: Approved" and "Completed"
+        Integer approvedQcStateId = EHRService.get().getQCStates(_container).get("Request: Approved").getRowId();
+        Integer completedQcStateId = EHRService.get().getQCStates(_container).get("Completed").getRowId();
+
+        // Query for rows matching the IDs and having "Request: Approved" status
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), ids, CompareType.IN);
+        filter.addCondition(FieldKey.fromString("qcstate"), approvedQcStateId, CompareType.EQUAL);
+
+        TableSelector ts = new TableSelector(ti, PageFlowUtil.set("objectid"), filter, null);
+        Map<String, Object>[] results = ts.getMapArray();
+
+        if (results.length == 0)
+        {
+            _log.info("No prc_order rows found with 'Request: Approved' status for the provided IDs");
+            return;
+        }
+
+        // Build the update rows
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (Map<String, Object> result : results)
+        {
+            Map<String, Object> row = new HashMap<>();
+            row.put("objectid", result.get("objectid"));
+            row.put("qcstate", completedQcStateId);
+            rows.add(row);
+        }
+
+        try
+        {
+            ti.getUpdateService().updateRows(_user, _container, rows, null, null, getExtraContext());
+            _log.info("Successfully updated " + rows.size() + " prc_order rows to 'Completed' status");
+        }
+        catch (Exception e)
+        {
+            _log.error("Error updating prc_order rows to completed", e);
+        }
+    }
+
     public void sendPregnancyOutcomeNotification(final String animalId, Map<String, Object> row) throws Exception
     {
         //check whether Notification is enabled


### PR DESCRIPTION
#### Rationale
Update procedure order status on death/departure to completed. This essentially closes the procedure order but is not necessarily indicating the procedure was done.

Also update the key on procedure schedule and reports so More Actions options will have consistent behavior there as on the prc order dataset.

#### Changes
* Add triggerhelper function to close procedure orders
* Add triggers to call the close procedure orders function
* Update the key of prc schedule and overdue prcs to lsid
* Update More Actions items to use lsid instead of objectid
