### PR TITLE
Treatment data entry refinement and overridable task views

### DIFF
--- a/nirc_ehr/resources/queries/ehr/my_tasks.query.xml
+++ b/nirc_ehr/resources/queries/ehr/my_tasks.query.xml
@@ -2,6 +2,7 @@
     <metadata>
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="my_tasks" tableDbType="TABLE">
+                <tableTitle>My Tasks</tableTitle>
                 <javaCustomizer class="org.labkey.ehr.table.DefaultEHRCustomizer" />
                 <insertUrl />
                 <updateUrl />

--- a/nirc_ehr/resources/queries/ehr/my_tasks/.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/my_tasks/.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView" label="All Tasks">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" label="All Tasks" canOverride="true">
    <columns>
        <column name="rowid"/>
        <column name="updateTitle" />

--- a/nirc_ehr/resources/queries/ehr/my_tasks/Active Tasks.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/my_tasks/Active Tasks.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
    <columns>
        <column name="rowid"/>
        <column name="updateTitle" />

--- a/nirc_ehr/resources/queries/ehr/my_tasks/Review Required.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/my_tasks/Review Required.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
    <columns>
        <column name="rowid"/>
        <column name="updateTitle" />

--- a/nirc_ehr/resources/queries/ehr/tasks/.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/tasks/.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView" label="All Tasks">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" label="All Tasks" canOverride="true">
    <columns>
        <column name="rowid"/>
        <column name="updateTitle" />

--- a/nirc_ehr/resources/queries/ehr/tasks/Active Tasks.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/tasks/Active Tasks.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
    <filters>
        <filter column="qcstate/PublicData" operator="eq" value="false"/>
    </filters>

--- a/nirc_ehr/resources/queries/ehr/tasks/Review Required.qview.xml
+++ b/nirc_ehr/resources/queries/ehr/tasks/Review Required.qview.xml
@@ -1,4 +1,4 @@
-<customView xmlns="http://labkey.org/data/xml/queryCustomView">
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
    <columns>
        <column name="rowid"/>
        <column name="updateTitle" />

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/TreatmentSchedule.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/TreatmentSchedule.js
@@ -18,7 +18,8 @@ EHR.model.DataModelManager.registerMetadata('TreatmentSchedule', {
                     schemaName: 'ehr_lookups',
                     queryName: 'snomed',
                     columns: 'code,meaning',
-                    sort: 'sort_order',
+                    sort: 'meaning,code',
+                    filterArray: [LABKEY.Filter.create('dateDisabled', null, LABKEY.Filter.Types.ISBLANK)],
                     autoLoad: true,
                     getRecordForCode: function(code){
                         debugger


### PR DESCRIPTION
#### Rationale
Treatment drop down should take date disabled into account and be sorted by meaning. Also make all the task and my_task views overridable.

#### Changes
* Treatment drop down query updates
* Overridable config in .qviews
