### PR TITLE
Stale element fix in tests

### DIFF
--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -582,6 +582,8 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         births.setGridCellJS(1, "date", now.minusDays(1).format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_STRING)));
         births.setGridCell(1, "Id", bornAnimal);
         births.setGridCell(1, "cage", "C3");
+        births.setGridCell(1, "Id/demographics/species", "Cebus apella CAP");
+        births.setGridCell(1, "Id/demographics/gender", "female");
         births.setGridCell(1, "project", "795644");
         births.setGridCell(1, "birthProtocol", "protocol101");
         submitForm("Submit Final", "Finalize");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -1307,7 +1307,8 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
     private void submitForm(String buttonText, String windowTitle)
     {
         //Give time for errors to disappear after validation
-        longWait().until(ExpectedConditions.invisibilityOfElementWithText(Locator.tag("div"), "The form has the following errors and warnings:"));
+        Locator.tagContainingText("div", "The form has the following errors and warnings:")
+                .waitForElementToDisappear(longWait());
         Locator submitFinalBtn = Locator.linkWithText(buttonText);
         shortWait().until(ExpectedConditions.elementToBeClickable(submitFinalBtn));
         Window<?> msgWindow;


### PR DESCRIPTION
#### Rationale
Upgrade of selenium exposed an area in the submit final where invisibilityOfElementWithText was getting stale element references due to an extjs re-render after initially getting element references. This refactor uses waitForElementToDisappear which seems to grab fresh elements refs whenever called.

Also fix a new issue in the birth form to fill in required fields.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2865

#### Changes
* Use waitForElementToDisappear
* Add required fields to birth form
