### PR TITLE
Handle rearrivals

### DIFF
--- a/nirc_ehr/resources/queries/study/arrival.js
+++ b/nirc_ehr/resources/queries/study/arrival.js
@@ -2,19 +2,15 @@ require("ehr/triggers").initScript(this);
 
 var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
 
-function onInit(event, helper){
-    helper.setScriptOptions({
-        allowAnyId: true,
-        requiresStatusRecalc: true,
-        allowDatesInDistantPast: true,
-        skipAssignmentCheck: true,
-    });
-}
-
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
 
+    console.log('isRearrival:', row.rearrival);
+    if(!row.rearrival){
+        helper.setScriptOptions({requiresStatusRecalc: true});
+    }
+
     // Due to order of operation, this needs to be done in upsert instead of insert
-    if (helper.getEvent() == 'insert' && row.Id && triggerHelper.animalIdExists(row.Id)) {
+    if (!row.rearrival && helper.getEvent() == 'insert' && row.Id && triggerHelper.animalIdExists(row.Id)) {
         EHR.Server.Utils.addError(scriptErrors, 'Id', 'Animal Id ' + row.Id + ' is already in use. Please use a different Id.', 'ERROR');
     }
 
@@ -25,7 +21,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
     helper.registerArrival(row.Id, row.date);
 
     //Insert or update demographic and birth records
-    if (!helper.isETL() && !helper.isGeneratedByServer() && !helper.isValidateOnly()) {
+    if (!row.rearrival && !helper.isETL() && !helper.isGeneratedByServer() && !helper.isValidateOnly()) {
 
         // this allows demographic records in qcstates other than completed
         var extraDemographicsFieldMappings = {

--- a/nirc_ehr/resources/queries/study/arrival.js
+++ b/nirc_ehr/resources/queries/study/arrival.js
@@ -4,7 +4,6 @@ var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.S
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'Arrival', function(helper, scriptErrors, row, oldRow) {
 
-    console.log('isRearrival:', row.rearrival);
     if(!row.rearrival){
         helper.setScriptOptions({requiresStatusRecalc: true});
     }

--- a/nirc_ehr/resources/queries/study/arrival.query.xml
+++ b/nirc_ehr/resources/queries/study/arrival.query.xml
@@ -69,6 +69,9 @@
                             <fkColumnName>meaning</fkColumnName>
                         </fk>
                     </column>
+                    <column columnName="rearrival">
+                        <columnTitle>Rearrival</columnTitle>
+                    </column>
                 </columns>
             </table>
         </tables>

--- a/nirc_ehr/resources/queries/study/arrival/.qview.xml
+++ b/nirc_ehr/resources/queries/study/arrival/.qview.xml
@@ -5,15 +5,14 @@
     <columns>
         <column name="Id"/>
         <column name="date"/>
-        <column name="gender"/>
-        <column name="species"/>
+        <column name="Id/Demographics/gender"/>
+        <column name="Id/Demographics/species"/>
         <column name="Id/Demographics/dam"/>
         <column name="Id/Demographics/sire"/>
         <column name="sourceFacility"/>
         <column name="acquisitionType"/>
         <column name="performedBy"/>
         <column name="history"/>
-        <column name="lab"/>
         <column name="attachmentFile"/>
     </columns>
 </customView>

--- a/nirc_ehr/resources/queries/study/protocolAssignment.js
+++ b/nirc_ehr/resources/queries/study/protocolAssignment.js
@@ -6,7 +6,6 @@ var prevDate;
 var missing = [];
 
 var count = 0;
-let animalIds = [];
 
 var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
 
@@ -31,12 +30,7 @@ function getLastAssignment(id){
 }
 
 function onInit(event, helper){
-
-    helper.setScriptOptions({
-        allowAnyId: false,
-        requiresStatusRecalc: true,
-        allowDatesInDistantPast: true
-    });
+    
     if (helper.isETL()) {
         LABKEY.Query.selectRows({
             schemaName: 'ehr',

--- a/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/nirc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
@@ -108,6 +108,9 @@
             <column columnName="arrivalType">
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="rearrival">
+                <datatype>boolean</datatype>
+            </column>
         </columns>
     </table>
     <table tableName="assignment" tableDbType="TABLE">

--- a/nirc_ehr/resources/scripts/nirc_triggers.js
+++ b/nirc_ehr/resources/scripts/nirc_triggers.js
@@ -26,10 +26,27 @@ exports.init = function (EHR) {
         });
     });
 
+    EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'arrival', function(event, helper) {
+        helper.setScriptOptions({
+            allowAnyId: true,
+            requiresStatusRecalc: false, // set in upsert to handle rearrival
+            allowDatesInDistantPast: true,
+            skipAssignmentCheck: true,
+        });
+    });
+
+    EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'protocolAssignment', function(event, helper) {
+        helper.setScriptOptions({
+            allowAnyId: false,
+            requiresStatusRecalc: false,
+            allowDatesInDistantPast: true
+        });
+    });
+
     EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'assignment', function(event, helper) {
         helper.setScriptOptions({
             allowAnyId: false,
-            requiresStatusRecalc: true,
+            requiresStatusRecalc: false,
             allowDatesInDistantPast: true,
             skipAssignmentCheck: true,
             removeTimeFromDate: false,

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/Arrival.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/Arrival.js
@@ -97,6 +97,11 @@ EHR.model.DataModelManager.registerMetadata('Arrival', {
                 columnConfig: {
                     width: 200
                 }
+            },
+            rearrival: {
+                allowBlank: true,
+                hidden: true,
+                showInGrid: false
             }
         }
     }

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/NIRCDefault.js
@@ -14,7 +14,7 @@ EHR.model.DataModelManager.registerMetadata('Default', {
             allowBlank: true,
             defaultValue: LABKEY.Security.currentUser.id,
             getInitialValue: function (v, rec) {
-                if (Number.isInteger(v)){
+                if (Number.isInteger(Number(v))){
                     return v;
                 }
 
@@ -140,7 +140,7 @@ EHR.model.DataModelManager.registerMetadata('Default', {
                     sort: 'Type,DisplayName'
                 },
                 getInitialValue: function (v, rec) {
-                    if (Number.isInteger(v)){
+                    if (Number.isInteger(Number(v))){
                         return v;
                     }
 

--- a/nirc_ehr/resources/web/nirc_ehr/model/sources/Rearrival.js
+++ b/nirc_ehr/resources/web/nirc_ehr/model/sources/Rearrival.js
@@ -1,0 +1,57 @@
+
+EHR.model.DataModelManager.registerMetadata('Rearrival', {
+
+    byQuery: {
+        'study.arrival': {
+            rearrival: {
+                getInitialValue: function (v, rec) {
+                    return true
+                },
+                editable: false,
+                hidden: true,
+                columnConfig: {
+                    editable: false
+                }
+            },
+            performedby: {
+                hidden: true,
+                showInGrid: false
+            },
+            sourceFacility: {
+                allowBlank: false,
+                columnConfig: {
+                    fixed: true,
+                    width: 150
+                },
+            },
+            acquisitionType: {
+                allowBlank: false,
+                columnConfig: {
+                    fixed: true,
+                    width: 150
+                },
+            },
+            arrivalType: {
+                allowBlank: false,
+                columnConfig: {
+                    width: 200
+                }
+            },
+            'cage': {
+                allowBlank: true,
+                hidden: true,
+                showInGrid: false
+            },
+            project: {
+                allowBlank: true,
+                hidden: true,
+                showInGrid: false
+            },
+            arrivalProtocol: {
+                allowBlank: true,
+                hidden: true,
+                showInGrid: false
+            },
+        }
+    }
+});

--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -236,6 +236,7 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCBehaviorRoundsFormType.class, this));
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCChemistryImportFormType.class, this));
         EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCSerologyImportFormType.class, this));
+        EHRService.get().registerFormType(new DefaultDataEntryFormFactory(NIRCRearrivalFormType.class, this));
     }
 
     @Override

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCRearrivalFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCRearrivalFormType.java
@@ -1,0 +1,45 @@
+package org.labkey.nirc_ehr.dataentry.form;
+
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+import org.labkey.api.ehr.dataentry.FormSection;
+import org.labkey.api.ehr.dataentry.forms.LockAnimalsFormSection;
+import org.labkey.api.module.Module;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.view.template.ClientDependency;
+import org.labkey.nirc_ehr.dataentry.section.NIRCAnimalDetailsFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCArrivalInstructionsFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCRearrivalFormSection;
+import org.labkey.nirc_ehr.dataentry.section.NIRCTaskFormSection;
+
+import java.util.Arrays;
+
+public class NIRCRearrivalFormType extends NIRCBaseTaskFormType
+{
+    public static final String NAME = "Rearrival";
+
+    public NIRCRearrivalFormType(DataEntryFormContext ctx, Module owner)
+    {
+        super(ctx, owner, NAME, "Rearrivals", "Colony Management", Arrays.asList(
+                new LockAnimalsFormSection(),
+                new NIRCArrivalInstructionsFormSection(),
+                new NIRCTaskFormSection(),
+                new NIRCAnimalDetailsFormSection(),
+                new NIRCRearrivalFormSection()
+        ));
+
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/Arrival.js"));
+        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/Rearrival.js"));
+
+        for (FormSection s : getFormSections())
+        {
+            s.addConfigSource("Arrival");
+            s.addConfigSource("Rearrival");
+        }
+    }
+
+    @Override
+    public boolean isAvailable()
+    {
+        return super.isAvailable() && getCtx().getContainer().hasPermission(getCtx().getUser(), AdminPermission.class);
+    }
+}

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCRearrivalFormType.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/form/NIRCRearrivalFormType.java
@@ -27,12 +27,10 @@ public class NIRCRearrivalFormType extends NIRCBaseTaskFormType
                 new NIRCRearrivalFormSection()
         ));
 
-        addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/Arrival.js"));
         addClientDependency(ClientDependency.supplierFromPath("nirc_ehr/model/sources/Rearrival.js"));
 
         for (FormSection s : getFormSections())
         {
-            s.addConfigSource("Arrival");
             s.addConfigSource("Rearrival");
         }
     }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCRearrivalFormSection.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/dataentry/section/NIRCRearrivalFormSection.java
@@ -1,0 +1,20 @@
+package org.labkey.nirc_ehr.dataentry.section;
+
+import org.json.JSONObject;
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+
+public class NIRCRearrivalFormSection extends BaseFormSection
+{
+    public NIRCRearrivalFormSection()
+    {
+        super("study", "arrival", "Rearrivals", "ehr-gridpanel", true, true, true);
+    }
+
+    @Override
+    public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
+    {
+        JSONObject json = super.toJSON(ctx, includeFormElements);
+        json.put("dataDependentCollapseHeader", true);
+        return json;
+    }
+}

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -878,9 +878,11 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         scrollIntoView(Locator.name("accessionNumber"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");
+        sleep(2000);
         Ext4FieldRef accessionNumber = _helper.getExt4FieldForFormSection("Necropsy", "Accession Number");
         accessionNumber.setValue("123");
         waitFor(() -> "123".equals(accessionNumber.getValue()), WAIT_FOR_JAVASCRIPT);
+        sleep(2000);
         scrollIntoView(Locator.name("diagnosis"));
         Ext4FieldRef identification = _helper.getExt4FieldForFormSection("Necropsy", "Name/State/License no. (quarantine only)");
         identification.setValue("Extra information");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -878,11 +878,19 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         scrollIntoView(Locator.linkContainingText("More Actions"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");
-        _helper.getExt4FieldForFormSection("Necropsy", "Accession Number").setValue("123");
+        Ext4FieldRef accessionNumber = _helper.getExt4FieldForFormSection("Necropsy", "Accession Number");
+        accessionNumber.setValue("123");
+        waitFor(() -> "123".equals(accessionNumber.getValue()), WAIT_FOR_JAVASCRIPT);
         scrollIntoView(Locator.name("diagnosis"));
-        _helper.setDataEntryField("identification", "Extra information");
-        _helper.setDataEntryField("grossAbnormalities", "Extra leg");
-        _helper.setDataEntryField("diagnosis", "Dead");
+        Ext4FieldRef identification = _helper.getExt4FieldForFormSection("Necropsy", "Name/State/License no. (quarantine only)");
+        identification.setValue("Extra information");
+        waitFor(() -> "Extra information".equals(identification.getValue()), WAIT_FOR_JAVASCRIPT);
+        Ext4FieldRef grossAbnormalities = _helper.getExt4FieldForFormSection("Necropsy", "Gross Abnormalities");
+        grossAbnormalities.setValue("Extra leg");
+        waitFor(() -> "Extra leg".equals(grossAbnormalities.getValue()), WAIT_FOR_JAVASCRIPT);
+        Ext4FieldRef diagnosis = _helper.getExt4FieldForFormSection("Necropsy", "Diagnosis");
+        diagnosis.setValue("Dead");
+        waitFor(() -> "Dead".equals(diagnosis.getValue()), WAIT_FOR_JAVASCRIPT);
         _ext4Helper.selectComboBoxItem("Performed By:", NIRC_BASIC_SUBMITTER_NAME);
 
         log("Entering Tissue Disposition");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -872,8 +872,9 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         log("Entering Necropsy");
         impersonate(NIRC_BASIC_SUBMITTER_VET_TECH);
         beginAt(url);
-        Ext4GridRef necropsy = _helper.getExt4GridForFormSection("Necropsy");
-        necropsy.expand();
+        _helper.getExt4GridForFormSection("Necropsy");
+        waitForElement(Ext4Helper.Locators.ext4Button("Submit Necropsy for Review"), WAIT_FOR_PAGE);
+        waitForElement(Ext4Helper.Locators.formItemWithLabel("Performed By:"), WAIT_FOR_PAGE);
         scrollIntoView(Locator.linkContainingText("More Actions"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -877,7 +877,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         scrollIntoView(Locator.linkContainingText("More Actions"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");
-        _helper.setDataEntryField("accessionNumber", "123");
+        _helper.getExt4FieldForFormSection("Necropsy", "Accession Number").setValue("123");
         scrollIntoView(Locator.name("diagnosis"));
         _helper.setDataEntryField("identification", "Extra information");
         _helper.setDataEntryField("grossAbnormalities", "Extra leg");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -882,7 +882,6 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         Ext4FieldRef accessionNumber = _helper.getExt4FieldForFormSection("Necropsy", "Accession Number");
         accessionNumber.setValue("123");
         waitFor(() -> "123".equals(accessionNumber.getValue()), WAIT_FOR_JAVASCRIPT);
-        sleep(2000);
         scrollIntoView(Locator.name("diagnosis"));
         Ext4FieldRef identification = _helper.getExt4FieldForFormSection("Necropsy", "Name/State/License no. (quarantine only)");
         identification.setValue("Extra information");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -875,7 +875,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         _helper.getExt4GridForFormSection("Necropsy");
         waitForElement(Ext4Helper.Locators.ext4Button("Submit Necropsy for Review"), WAIT_FOR_PAGE);
         waitForElement(Ext4Helper.Locators.formItemWithLabel("Performed By:"), WAIT_FOR_PAGE);
-        scrollIntoView(Locator.linkContainingText("More Actions"));
+        scrollIntoView(Locator.name("accessionNumber"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");
         Ext4FieldRef accessionNumber = _helper.getExt4FieldForFormSection("Necropsy", "Accession Number");

--- a/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
+++ b/nirc_ehr/test/src/org.labkey.test/tests.nirc_ehr/NIRC_EHRTest.java
@@ -878,7 +878,7 @@ public class NIRC_EHRTest extends AbstractGenericEHRTest implements PostgresOnly
         scrollIntoView(Locator.name("accessionNumber"));
         _ext4Helper.selectComboBoxItem("Physical Condition:", "Excellent");
         _ext4Helper.selectComboBoxItem("Condition of Specimen:", "Fresh");
-        sleep(2000);
+        sleep(1000);
         Ext4FieldRef accessionNumber = _helper.getExt4FieldForFormSection("Necropsy", "Accession Number");
         accessionNumber.setValue("123");
         waitFor(() -> "123".equals(accessionNumber.getValue()), WAIT_FOR_JAVASCRIPT);


### PR DESCRIPTION
#### Rationale
Some animals leave and come back. The EHR system doesn't really handle this. This is a work around to allow multiple arrivals and allow protocol/project assignments on animals with multiple arrivals. Some manual data manipulation still required.

Also a housing performedby fix.

[Ticket 54440](https://www.labkey.org/NIRC/Support%20Tickets/issues-details.view?issueId=54440): Unable to have multiple arrivals
[Ticket 54425](https://www.labkey.org/NIRC/Support%20Tickets/issues-details.view?issueId=54425): Housing Add From File Peformed By

#### Changes
* Fix data type issue on performedby default values
* Add rearrival form.
* Update triggers to prevent reusing Id on arrival but not rearrival
* Update assignment triggers
