### PR TITLE
Ticket 54467: Correct a death record

### DIFF
--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -71,7 +71,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
     if (!helper.isETL()) {
 
-        //skip other checks so that admin to update a death record
+        //skip other checks so that the admins can update a death record
         if (helper.getEvent() === 'update' && LABKEY.Security.currentUser.isAdmin) {
             return;
         }

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -71,6 +71,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
     if (!helper.isETL()) {
 
+        //skip other checks so that admin to update a death record
         if (helper.getEvent() === 'update' && LABKEY.Security.currentUser.isAdmin) {
             return;
         }

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -4,6 +4,7 @@ var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.S
 var validIds = [];
 var idMap = {};
 var deathIdMap = {};
+var taskIds = {};
 
 function onInit(event, helper){
 
@@ -71,11 +72,15 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
 
     if (!helper.isETL()) {
 
-        //only allow death record to be created if animal is in demographics table
+        if (helper.getEvent() === 'update' && LABKEY.Security.currentUser.isAdmin) {
+            return;
+        }
+
+        //only allow death record to be created if the animal is in the demographics table
         if (idMap[row.Id]) {
 
-            // check if death record already exists for this animal
-            if (idMap[row.Id].calculated_status.toUpperCase() === 'DEAD' && row.QCStateLabel.toUpperCase() === 'COMPLETED') {
+            // check if a death record already exists for this animal
+            if (idMap[row.Id].calculated_status.toUpperCase() === 'DEAD' && deathIdMap[row.Id].QCStateLabel.toUpperCase() === 'COMPLETED') {
                 EHR.Server.Utils.addError(scriptErrors, 'Id', 'Death record already exists for this animal.', 'ERROR');
             }
             // check if the animal is at the center

--- a/nirc_ehr/resources/queries/study/deaths.js
+++ b/nirc_ehr/resources/queries/study/deaths.js
@@ -4,7 +4,6 @@ var triggerHelper = new org.labkey.nirc_ehr.query.NIRC_EHRTriggerHelper(LABKEY.S
 var validIds = [];
 var idMap = {};
 var deathIdMap = {};
-var taskIds = {};
 
 function onInit(event, helper){
 

--- a/nirc_ehr/resources/views/datasets.html
+++ b/nirc_ehr/resources/views/datasets.html
@@ -6,7 +6,7 @@ Ext4.onReady(function () {
 
     const config = {displayField: 'Label', headerField: 'categoryId/label', target: webpart.wrapperDivId};
 
-    const nonFormUpdates = ["Cases", "Procedures", "Drug Administration"];
+    const nonFormUpdates = ["Treatment Cases", "Procedures", "Drug Administration", "Deaths"];
 
     const hideUpdateRecords = [];
 
@@ -67,8 +67,7 @@ Ext4.onReady(function () {
 
                 if(EHR.Security.hasPermission('Completed', 'update', {schemaName: 'study', queryName: item.queryName}) && hideUpdateRecords.indexOf(item.queryName) === -1){
 
-                    //'Deaths' is a special case where we want to skip the 'Update Records' link, only Admins can update Death records.
-                    if(item.queryName === 'Deaths') {
+                    if(nonFormUpdates.indexOf(item.queryName) !== -1) {
                         //adding an item here so that the 'Admin Update Records' link aligns with other links in the same "column"
                         cfg.items.push({
                             xtype: 'box',

--- a/nirc_ehr/resources/views/datasets.html
+++ b/nirc_ehr/resources/views/datasets.html
@@ -66,7 +66,10 @@ Ext4.onReady(function () {
                     params.queryUpdateURL = true;
 
                 if(EHR.Security.hasPermission('Completed', 'update', {schemaName: 'study', queryName: item.queryName}) && hideUpdateRecords.indexOf(item.queryName) === -1){
+
+                    //'Deaths' is a special case where we want to skip the 'Update Records' link, only Admins can update Death records.
                     if(item.queryName === 'Deaths') {
+                        //adding an item here so that the 'Admin Update Records' link aligns with other links in the same "column"
                         cfg.items.push({
                             xtype: 'box',
                             html: '<span><a class="labkey-text-link" style="cursor: pointer; visibility: hidden;">Update Records</a></span>'

--- a/nirc_ehr/resources/views/datasets.html
+++ b/nirc_ehr/resources/views/datasets.html
@@ -66,12 +66,20 @@ Ext4.onReady(function () {
                     params.queryUpdateURL = true;
 
                 if(EHR.Security.hasPermission('Completed', 'update', {schemaName: 'study', queryName: item.queryName}) && hideUpdateRecords.indexOf(item.queryName) === -1){
-                    cfg.items.push({
+                    if(item.queryName === 'Deaths') {
+                        cfg.items.push({
+                            xtype: 'box',
+                            html: '<span><a class="labkey-text-link" style="cursor: pointer; visibility: hidden;">Update Records</a></span>'
+                        });
+                    }
+                    else {
+                     cfg.items.push({
                         xtype: 'ldk-linkbutton',
                         tooltip: item.searchTooltip || 'Click to update records',
                         href: LABKEY.ActionURL.buildURL('ehr', 'updateQuery', null, params),
                         text: 'Update Records'
                     });
+                    }
                 }
 
                 params.queryUpdateURL = true;


### PR DESCRIPTION
#### Rationale
Ticket [54467](https://www.labkey.org/NIRC/Support%20Tickets/issues-details.view?issueId=54467
): Correct a death record

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Allow admins to update an existing Death record without triggering a duplicate record error.