### PR TITLE
Medication duplicates

### DIFF
--- a/nirc_ehr/resources/queries/study/treatmentSchedule.sql
+++ b/nirc_ehr/resources/queries/study/treatmentSchedule.sql
@@ -5,7 +5,7 @@ d_alias.alias AS Name,
 d.calculated_status,
 s.*,
 s.objectid AS treatmentid,
-drug.qcstate.label AS treatmentStatus,
+drug.treatmentStatus,
 s.objectid || '-pkSeparator-' || s.date AS primaryKey -- -pkSeparator- is used to separate the two parts of the primary key in RecordTreatmentButton.js
 FROM study.demographics d
 JOIN(
@@ -64,7 +64,11 @@ JOIN(
     ) s1
 
 ) s ON (s.animalid = d.id) 
-LEFT JOIN study.drug drug ON s.objectid = drug.treatmentid AND s.date = IFDEFINED(drug.scheduledDate)
+LEFT JOIN (
+    SELECT treatmentid, IFDEFINED(scheduledDate) AS scheduledDate, MAX(qcstate.label) AS treatmentStatus
+    FROM study.drug
+    GROUP BY treatmentid, IFDEFINED(scheduledDate)
+) drug ON s.objectid = drug.treatmentid AND s.date = drug.scheduledDate
 LEFT JOIN (SELECT Id, GROUP_CONCAT(alias, ', ') alias FROM alias WHERE category.title = 'Name' GROUP BY Id) d_alias ON d.id = d_alias.id
 WHERE (d.lastDayatCenter IS NULL OR d.lastDayAtCenter > s.enddate OR s.enddate IS NULL)
     AND s.date >= s.startDate AND (s.enddate IS NULL OR s.date <= s.enddate)

--- a/nirc_ehr/resources/views/necropsy.html
+++ b/nirc_ehr/resources/views/necropsy.html
@@ -71,6 +71,7 @@
                 schemaName: 'study',
                 queryName: 'necropsy',
                 filterArray: filterArray,
+                columns: 'date,accessionNumber,specimenCondition,physicalCondition,relevantHistory,grossAbnormalities,diagnosis,identification,performedby',
             },
             title: 'Necropsy',
             renderTo: 'animalNecropsy',

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/ProcedureOrderCompleteButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/ProcedureOrderCompleteButton.js
@@ -36,8 +36,10 @@ Ext4.define('NIRC_EHR.window.ProcedureOrderCompleteWindow', {
 
     recordProcedure: function(btn, dataRegion) {
         let win = btn.up('window');
-        const selectedRows = dataRegion.getChecked();
+        const selectedRows = [...new Set(dataRegion.getChecked())];
         var me = this;
+        btn.setDisabled(true);
+        Ext4.Msg.wait('Completing procedure orders...');
 
         LABKEY.Query.selectRows({
             schemaName: 'core',
@@ -72,12 +74,14 @@ Ext4.define('NIRC_EHR.window.ProcedureOrderCompleteWindow', {
                         win.close();
                     },
                     failure: function(error) {
+                        btn.setDisabled(false);
                         Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred while recording procedure orders.');
                         console.error(error);
                     }
                 });
             },
             failure: function(error) {
+                btn.setDisabled(false);
                 Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred querying qcstates.');
                 console.error(error);
             }

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/RecordProcedureButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/RecordProcedureButton.js
@@ -65,8 +65,10 @@ Ext4.define('NIRC_EHR.window.RecordProcedureWindow', {
         let win = btn.up('window');
         let windDate = win.down('#dateField').getValue();
         let performedBy = win.down('#performedBy').getValue();
-        const selectedRows = dataRegion.getChecked();
+        const selectedRows = [...new Set(dataRegion.getChecked())];
         var me = this;
+        btn.setDisabled(true);
+        Ext4.Msg.wait('Recording procedures...');
 
         LABKEY.Query.selectRows({
             schemaName: 'study',
@@ -109,12 +111,14 @@ Ext4.define('NIRC_EHR.window.RecordProcedureWindow', {
                         win.close();
                     },
                     failure: function(error) {
+                        btn.setDisabled(false);
                         Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred while recording procedures.');
                         console.error(error);
                     }
                 });
             },
             failure: function(error) {
+                btn.setDisabled(false);
                 Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred querying procedures.');
                 console.error(error);
             }

--- a/nirc_ehr/resources/web/nirc_ehr/buttons/RecordTreatmentButton.js
+++ b/nirc_ehr/resources/web/nirc_ehr/buttons/RecordTreatmentButton.js
@@ -65,9 +65,11 @@ Ext4.define('NIRC_EHR.window.RecordTreatmentWindow', {
         let win = btn.up('window');
         let windDate = win.down('#dateField').getValue();
         let performedBy = win.down('#performedBy').getValue();
-        const selectedRows = dataRegion.getChecked();
+        const selectedRows = [...new Set(dataRegion.getChecked())];
         const objectIds = selectedRows.map(row => row.split('-pkSeparator-')[0]);
         var me = this;
+        btn.setDisabled(true);
+        Ext4.Msg.wait('Recording treatments...');
 
         LABKEY.Query.selectRows({
             schemaName: 'study',
@@ -75,7 +77,7 @@ Ext4.define('NIRC_EHR.window.RecordTreatmentWindow', {
             filterArray: [LABKEY.Filter.create('objectid', objectIds.join(';'), LABKEY.Filter.Types.EQUALS_ONE_OF)],
             scope: this,
             ignoreFilter: true,
-            columns: 'Id,objectid,code,reason,route,amount,amount_units,concentration,volume,vol_units,conc_units,dosage,dosage_units,orderedby,category,caseid',
+            columns: 'Id,objectid,code,route,amount,amount_units,concentration,volume,vol_units,conc_units,dosage,dosage_units,orderedby,category,caseid',
             success: function (data) {
                 const rowsToInsert = [];
                 Ext4.each(data.rows, function(row) {
@@ -94,7 +96,6 @@ Ext4.define('NIRC_EHR.window.RecordTreatmentWindow', {
                                 objectid: LABKEY.Utils.generateUUID(),
                                 scheduledDate: scheduledDate,
                                 code: row.code,
-                                reason: row.reason,
                                 route: row.route,
                                 amount: row.amount,
                                 amount_units: row.amount_units,
@@ -106,8 +107,7 @@ Ext4.define('NIRC_EHR.window.RecordTreatmentWindow', {
                                 vol_units: row.vol_units,
                                 orderedby: row.orderedby,
                                 category: row.category,
-                                caseid: row.caseid,
-                                outcome: 'Normal'
+                                caseid: row.caseid
                             });
                         }
                     });
@@ -127,12 +127,14 @@ Ext4.define('NIRC_EHR.window.RecordTreatmentWindow', {
                         win.close();
                     },
                     failure: function(error) {
+                        btn.setDisabled(false);
                         Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred while recording treatments.');
                         console.error(error);
                     }
                 });
             },
             failure: function(error) {
+                btn.setDisabled(false);
                 Ext4.Msg.alert('Error', error?.exception ?? 'An error occurred querying treatments.');
                 console.error(error);
             }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/table/NIRC_EHRCustomizer.java
@@ -1109,6 +1109,7 @@ public class NIRC_EHRCustomizer extends AbstractTableCustomizer
                             keys.add(getBoundColumn().getFieldKey());
                             keys.add(FieldKey.fromString("date"));
                             keys.add(FieldKey.fromString("caseid"));
+                            keys.add(FieldKey.fromString("category"));
                         }
 
                         @Override


### PR DESCRIPTION
#### Rationale
Looks like fast users and slow server is leading to multiple bulk treatment submits/transactions being queued before triggers can throw error. This PR will disable the submit button and show loading modal. Same behavior applied to procedure schedule. Tighten up a few other things to ensure no other potential duplicates.

Add performedby to necropsy report.

#### Changes
* Disable submit buttons as described above.
* Ensure no duplicates in schedule when dupes in drug.
* Ensure no duplicates in selected row pks
* Add columns to necropsy section of necropsy report.
* Fix dependent column issue with category
