### PR TITLE
Animals are treated as "Alive" when the data is in Draft or Review Requested status.

### DIFF
--- a/nirc_ehr/resources/data/calculated_status_codes.tsv
+++ b/nirc_ehr/resources/data/calculated_status_codes.tsv
@@ -1,0 +1,7 @@
+code
+Alive
+Alive - In Progress
+Dead
+ERROR
+No Record
+Shipped

--- a/nirc_ehr/resources/data/editable_lookups.tsv
+++ b/nirc_ehr/resources/data/editable_lookups.tsv
@@ -23,6 +23,7 @@ ehr_lookups	blood_draw_tube_type	Clinical	Blood Draw Tube Type	Used in blood dra
 ehr_lookups	blood_sample_type	Clinical	Blood Sample Types	Used in blood draw datasets.
 ehr_lookups	blood_tube_volumes	Clinical	Blood Tube Volumes	Used in blood draw datasets.
 ehr_lookups	cage_type	Colony Management	Cage Type	Used in cage details.
+ehr_lookups	calculated_status_codes	Colony Management	Calculated Status	Animal status values.
 ehr_lookups	capillary_refill_time	Clinical	Capillary Refill Times	Used clinical observations.
 ehr_lookups	card_format	Colony Management	Card Format	
 ehr_lookups	census_activity_status	Colony Management	Census Activity Status	

--- a/nirc_ehr/resources/data/lookup_sets.tsv
+++ b/nirc_ehr/resources/data/lookup_sets.tsv
@@ -19,7 +19,6 @@ behavior_types	Behavior Types	value
 blood_draw_reason	Blood Draw Reason	value
 blood_sample_type	Blood Sample Types	value
 cage_type	Cage Type	value	title
-calculated_status_codes	Calculated Status Codes	value
 capillary_refill_time	Capillary Refill Time	value
 card_format	Card Format	value	title
 census_activity_status	Census Activity Status	value	title

--- a/nirc_ehr/resources/data/lookup_sets.tsv
+++ b/nirc_ehr/resources/data/lookup_sets.tsv
@@ -18,9 +18,10 @@ behavior_mgmt_codes	Behavior Management Codes	value
 behavior_types	Behavior Types	value
 blood_draw_reason	Blood Draw Reason	value
 blood_sample_type	Blood Sample Types	value
-card_format	Card Format	value	title
 cage_type	Cage Type	value	title
+calculated_status_codes	Calculated Status Codes	value
 capillary_refill_time	Capillary Refill Time	value
+card_format	Card Format	value	title
 census_activity_status	Census Activity Status	value	title
 clinremarks_category	Clinremarks Category	value	title
 congenital_abnormalities	Congenital Abnormalities	value	title

--- a/nirc_ehr/resources/data/lookupsManifest.tsv
+++ b/nirc_ehr/resources/data/lookupsManifest.tsv
@@ -23,6 +23,7 @@ blood_draw_tube_type
 blood_sample_type
 blood_tube_volumes
 cage_type
+calculated_status_codes
 capillary_refill_time
 card_format
 census_activity_status

--- a/nirc_ehr/resources/data/lookupsManifestTest.tsv
+++ b/nirc_ehr/resources/data/lookupsManifestTest.tsv
@@ -22,6 +22,7 @@ blood_draw_tube_type
 blood_sample_type
 blood_tube_volumes
 cage_type
+calculated_status_codes
 capillary_refill_time
 card_format
 census_activity_status

--- a/nirc_ehr/resources/queries/study/aliases.sql
+++ b/nirc_ehr/resources/queries/study/aliases.sql
@@ -2,7 +2,7 @@
 
 SELECT Id,
        Id as alias
-FROM study.Animal
+FROM study.Animal where Dataset.Demographics.calculated_status != 'Alive - In Progress'
 UNION
 SELECT Id,
     Name as alias
@@ -10,4 +10,5 @@ FROM nirc_ehr.IdHistory
 UNION
 SELECT Id,
     Alias as alias
-FROM study.alias
+FROM study.alias where Id.demographics.calculated_status != 'Alive - In Progress'
+'

--- a/nirc_ehr/resources/queries/study/arrival.js
+++ b/nirc_ehr/resources/queries/study/arrival.js
@@ -96,6 +96,8 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
             }
         }
 
+        row.calculated_status = (row.QCStateLabel.toUpperCase() === 'IN PROGRESS' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED') ? 'Alive - In Progress' : 'Alive';
+
         if(!oldRow) {
             //if not already present, insert into demographics
             helper.getJavaHelper().createDemographicsRecord(row.Id, row, extraDemographicsFieldMappings);

--- a/nirc_ehr/resources/queries/study/birth.js
+++ b/nirc_ehr/resources/queries/study/birth.js
@@ -78,10 +78,12 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
                 'qcstate': helper.getJavaHelper().getQCStateForLabel(row.QCStateLabel).getRowId()
             }
 
+            var calc_status = (row.QCStateLabel.toUpperCase() === 'IN PROGRESS' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED') ? 'Alive - In Progress' : 'Alive';
+
             var obj = {
                 Id: row.Id,
                 date: row.date,
-                calculated_status: (row.QCStateLabel.toUpperCase() === 'IN PROGRESS' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED') ? 'Alive - In Progress' : 'Alive',
+                calculated_status: calc_status,
                 dam: row['Id/demographics/dam'] || null,
                 sire: row['Id/demographics/sire'] || null,
                 species: row['Id/demographics/species'] || null,

--- a/nirc_ehr/resources/queries/study/birth.js
+++ b/nirc_ehr/resources/queries/study/birth.js
@@ -81,7 +81,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
             var obj = {
                 Id: row.Id,
                 date: row.date,
-                calculated_status: 'Alive',
+                calculated_status: (row.QCStateLabel.toUpperCase() === 'IN PROGRESS' || row.QCStateLabel.toUpperCase() === 'REVIEW REQUIRED') ? 'Alive - In Progress' : 'Alive',
                 dam: row['Id/demographics/dam'] || null,
                 sire: row['Id/demographics/sire'] || null,
                 species: row['Id/demographics/species'] || null,


### PR DESCRIPTION
#### Rationale
When a user creates an Arrivals or Birth record in a _Draft_ or _Review Requested_ state, the calculated_status in Demographics is set to "Alive."

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add a new calculated status code 'Alive - In Progress'.
* Update the Birth and Arrival triggers to set the calculated status to "Alive - In Progress" when the QCState is "In Progress" or "Review Requested."
