### PR TITLE
SQL Server to Postgres Migration

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/NIRC_EHRModule.java
@@ -183,7 +183,6 @@ public class NIRC_EHRModule extends ExtendedSimpleModule
 
         EHRService.get().registerMoreActionsButton(new ShowEditUIButton(this, "ehr", "observation_types", EHRDataAdminPermission.class), "ehr", "observation_types");
 
-        EHRService.get().unregisterMoreActionsButtons("study", "treatment_order");
         EHRService.get().registerMoreActionsButton(new MarkCompletedButton(this, "study", "observation_order", "Set End Date"), "study", "observation_order");
         EHRService.get().registerMoreActionsButton(new MarkCompletedButton(this, "study", "flags", "Set End Date"), "study", "flags");
 


### PR DESCRIPTION
#### Rationale
Remove unregisterMoreActionsButtons() - previously added for NIRC with the intention to remove some of the default or previously added more actions menu items for treatment_order. But this is no longer needed. Also, its breaking the TC tests when both NIRC and TNPRC on postgres are present - TNPRC adds the menu item it needs during startup, and NIRC globally unregisters it causing TNPRC test failure.

#### Related Pull Requests
* https://github.com/LabKey/tnprcEHRModules/pull/276

#### Changes
* Remove the unregister more actions in NIRCModule 
