### PR TITLE
Override editUIButtonHandler to set showImport=false

### DIFF
--- a/nirc_ehr/resources/web/nirc_ehr/nircOverrides.js
+++ b/nirc_ehr/resources/web/nirc_ehr/nircOverrides.js
@@ -1,1 +1,11 @@
 EHR.Utils.rowEditorPlugin = 'NIRC_EHR.plugin.RowEditor';
+
+EHR.Utils.editUIButtonHandler = function(schemaName, queryName, dataRegionName, paramMap, copyFilters){
+    var params = {
+        schemaName: schemaName,
+        'query.queryName': queryName,
+        showImport: false
+    };
+
+    this.editUIButtonCore(schemaName, queryName, dataRegionName, paramMap, undefined, params);
+};


### PR DESCRIPTION
#### Rationale
The base `EHR.Utils.editUIButtonHandler` passes `showImport: true` to
`/ehr/updateQuery`, which surfaces a bulk-import affordance on the edit
view. That path lets users insert/update records without going through
the EHR data-entry forms and without an admin permission gate. This PR
buttons up that path in the NIRC deployment.

#### Changes
* Override `EHR.Utils.editUIButtonHandler` in
  `nirc_ehr/resources/web/nirc_ehr/nircOverrides.js` to pass
  `showImport: false` while delegating to the base
  `EHR.Utils.editUIButtonCore`. The override piggybacks on NIRC's
  existing `nircOverrides.js`, already registered as an EHR client
  dependency in `NIRC_EHRModule.java`. No changes to the base `ehr`
  module.