### PR TITLE
Escape data values in Arrival and Birth clinical-history HTML

### DIFF
--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/ArrivalDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/ArrivalDataSource.java
@@ -4,7 +4,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.Results;
 import org.labkey.api.ehr.history.AbstractDataSource;
 import org.labkey.api.module.Module;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.sql.SQLException;
@@ -30,8 +29,7 @@ public class ArrivalDataSource extends AbstractDataSource
 
         sb.append(safeAppend(rs, "Arrival Type", "arrivalType"));
         sb.append(safeAppend(rs, "Acquisition Type", "acquisitionType"));
-        if (rs.hasColumn(FieldKey.fromString("sourceFacility")) && rs.getObject(FieldKey.fromString("sourceFacility")) != null)
-            sb.append("Lab Transfer From: " + rs.getString(FieldKey.fromString("sourceFacility")));
+        sb.append(safeAppend(rs, "Lab Transfer From", "sourceFacility"));
 
         return sb.toString();
     }

--- a/nirc_ehr/src/org/labkey/nirc_ehr/history/BirthDataSource.java
+++ b/nirc_ehr/src/org/labkey/nirc_ehr/history/BirthDataSource.java
@@ -4,7 +4,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.Results;
 import org.labkey.api.ehr.history.AbstractDataSource;
 import org.labkey.api.module.Module;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.sql.SQLException;
@@ -27,11 +26,6 @@ public class BirthDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
-
-        if(rs.hasColumn(FieldKey.fromString("Id/Demographics/gender/meaning")) && rs.getObject(FieldKey.fromString("Id/Demographics/gender/meaning")) != null)
-            sb.append("Gender: " + rs.getString(FieldKey.fromString("Id/Demographics/gender/meaning")));
-
-        return sb.toString();
+        return safeAppend(rs, "Gender", "Id/Demographics/gender/meaning");
     }
 }


### PR DESCRIPTION
## Rationale

BirthDataSource and ArrivalDataSource concatenated a data-controlled column value (the gender lookup display value and the sourceFacility value, respectively) directly into the clinical-history HTML without escaping. That HTML is serialized to the history row's html property and rendered unescaped in the EHR client, so a crafted value persisted and executed as stored XSS when a user viewed the animal's clinical history.

## Related Pull Requests

None.

## Changes

- Route both values through the base-class safeAppend helper, which HTML-escapes via PageFlowUtil.filter, matching every other nirc_ehr data source.
- Drop the now-redundant manual hasColumn/null guards and the now-unused FieldKey import.