### PR TITLE
Remove use of deprecated flatDir repository

### DIFF
--- a/nirc_ehr/build.gradle
+++ b/nirc_ehr/build.gradle
@@ -15,10 +15,6 @@
  */
 import org.labkey.gradle.util.BuildUtils
 
-repositories
-        {
-            flatDir dirs: project(":server:modules:LabDevKitModules:LDK").file("lib")
-        }
 dependencies
         {
             BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")


### PR DESCRIPTION
#### Rationale
 The use of `flatDir` with a map argument has been [deprecated](https://docs.gradle.org/9.6.0/userguide/upgrading_version_9.html#deprecated_repository_handler_map_overloads) and support will be removed in Gradle 10.0. The syntax could be updated to a non-deprecated syntax, but I don't think the declaration of the project lib directory as a repository should be needed.

#### Changes
* Remove declaration of LDK lib directory as repository for build
